### PR TITLE
Fix hero background slideshow, unify all pages, add Arsenal 001

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,161 +6,173 @@
 <title>About Us | Contractor Arsenal</title>
 <meta name="description" content="Learn what makes Contractor Arsenal different. We build professional contractor websites that generate real leads and revenue.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700;800;900&family=Barlow+Condensed:wght@700;800;900&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700;800;900&family=Barlow+Condensed:wght@600;700;800;900&family=Bebas+Neue&display=swap" rel="stylesheet">
 <style>
-*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-html{scroll-behavior:smooth}
 :root{
-  --bg:#1F1F1F;--bg2:#282828;--bg3:#303030;--bg4:#3a3a3a;
-  --border:rgba(255,255,255,0.08);--border2:rgba(255,255,255,0.16);
-  --red:#EF4444;--red2:#DC2626;--red3:#F87171;
-  --red-dim:rgba(239,68,68,0.12);--red-bg:rgba(239,68,68,0.08);
-  --gold:#F59E0B;--gold2:#FBBF24;--gold-dim:rgba(245,158,11,0.12);
-  --text:#F5F5F5;--text2:#C0C0C0;--text3:#888;--text4:#555;
-  --shadow:0 2px 16px rgba(0,0,0,0.35);--shadow2:0 8px 40px rgba(0,0,0,0.5);
-  --r:8px;--r2:12px;
+  --bg:#0a0a0a;--surface:#111111;--surface2:#1a1a1a;
+  --border:rgba(255,255,255,0.08);
+  --red:#C0392B;--red-light:#E74C3C;
+  --gold:#F97316;--gold-light:#FB923C;
+  --text:#f0f0f0;--muted:#888;--radius:12px;
 }
-body{font-family:'Barlow',sans-serif;background:var(--bg);color:var(--text);line-height:1.6;overflow-x:hidden}
-::-webkit-scrollbar{width:4px}
-::-webkit-scrollbar-track{background:var(--bg2)}
-::-webkit-scrollbar-thumb{background:var(--red);border-radius:4px}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
+html{scroll-behavior:smooth;}
+body{background:var(--bg);color:var(--text);font-family:'Barlow',sans-serif;overflow-x:hidden;line-height:1.6;}
+a{color:inherit;text-decoration:none;}
+img{max-width:100%;height:auto;display:block;}
+::-webkit-scrollbar{width:4px;}
+::-webkit-scrollbar-track{background:var(--surface);}
+::-webkit-scrollbar-thumb{background:var(--red);border-radius:4px;}
 
-/* NAV */
-nav{position:sticky;top:0;z-index:100;background:rgba(31,31,31,0.97);backdrop-filter:blur(16px);border-bottom:1px solid var(--border);height:64px;display:flex;align-items:center;padding:0 2rem;box-shadow:0 1px 20px rgba(0,0,0,0.4)}
-.nav-inner{max-width:1200px;margin:0 auto;width:100%;display:flex;align-items:center;gap:2rem}
-.nav-logo{display:flex;align-items:center;gap:0.6rem;text-decoration:none;flex-shrink:0}
-.nav-logo img{height:40px;width:auto}
-.nav-logo-text{font-size:1rem;font-weight:900;color:var(--text);font-family:'Barlow Condensed',sans-serif;letter-spacing:0.03em}
-.nav-links{display:flex;gap:0;list-style:none;margin-left:1rem}
-.nav-links a{padding:0.5rem 1rem;font-size:0.87rem;color:var(--text3);text-decoration:none;border-radius:6px;transition:color 0.2s;font-weight:600}
-.nav-links a:hover,.nav-links a.active{color:var(--text)}
-.nav-right{margin-left:auto;display:flex;gap:0.6rem;align-items:center}
-.nav-btn-primary{background:var(--red);color:#fff;border:none;padding:0.5rem 1.15rem;border-radius:6px;font-size:0.82rem;font-weight:700;text-decoration:none;display:flex;align-items:center;gap:0.4rem;transition:all 0.2s;font-family:'Barlow',sans-serif}
-.nav-btn-primary:hover{background:var(--red2);transform:translateY(-1px)}
-.hamburger{display:none;flex-direction:column;gap:5px;cursor:pointer;padding:8px;margin-left:auto;background:none;border:none}
-.hamburger span{display:block;width:22px;height:2px;background:var(--text);border-radius:2px;transition:all 0.3s}
-.hamburger.open span:nth-child(1){transform:translateY(7px) rotate(45deg)}
-.hamburger.open span:nth-child(2){opacity:0;transform:scaleX(0)}
-.hamburger.open span:nth-child(3){transform:translateY(-7px) rotate(-45deg)}
-.mobile-menu{display:none;position:fixed;top:64px;left:0;right:0;bottom:0;background:rgba(31,31,31,0.99);backdrop-filter:blur(20px);z-index:99;flex-direction:column;padding:2rem 1.5rem;gap:0;overflow-y:auto;border-top:1px solid var(--border)}
-.mobile-menu.open{display:flex}
-.mobile-menu a{padding:1rem 0;font-size:1.1rem;font-weight:700;color:var(--text2);text-decoration:none;border-bottom:1px solid var(--border);display:block}
-.mobile-menu a:hover{color:var(--red)}
+/* ── NAV ── */
+nav{position:fixed;top:0;left:0;right:0;z-index:1000;padding:0 5%;display:flex;align-items:center;justify-content:space-between;height:68px;background:rgba(10,10,10,0.95);backdrop-filter:blur(14px);border-bottom:1px solid var(--border);}
+.nav-logo{display:flex;align-items:center;gap:.6rem;}
+.nav-logo img{height:38px;width:auto;}
+.nav-logo-text{font-family:'Barlow Condensed',sans-serif;font-weight:900;font-size:1.1rem;letter-spacing:.05em;color:var(--text);}
+.nav-links{display:flex;gap:1.5rem;align-items:center;}
+.nav-links a{font-weight:600;font-size:.82rem;letter-spacing:.5px;text-transform:uppercase;color:var(--text);opacity:.75;transition:opacity .2s;}
+.nav-links a:hover{opacity:1;}
+.nav-links a.active{opacity:1;color:var(--gold);}
+.nav-cta{background:var(--red);color:#fff !important;padding:.5rem 1.25rem;border-radius:6px;font-weight:700;opacity:1 !important;transition:background .2s;}
+.nav-cta:hover{background:var(--red-light);}
+.nav-hamburger{display:none;flex-direction:column;gap:5px;cursor:pointer;padding:4px;background:none;border:none;}
+.nav-hamburger span{display:block;width:24px;height:2px;background:var(--text);border-radius:2px;transition:.3s;}
+.nav-mobile{display:none;position:fixed;top:68px;left:0;right:0;background:rgba(10,10,10,.98);padding:1.5rem 5%;flex-direction:column;gap:0;z-index:999;border-bottom:1px solid var(--border);}
+.nav-mobile.open{display:flex;}
+.nav-mobile a{font-weight:600;font-size:1rem;text-transform:uppercase;letter-spacing:.5px;padding:.9rem 0;border-bottom:1px solid var(--border);color:var(--text);}
+.nav-mobile a:hover{color:var(--gold);}
 
-/* HERO */
-.hero{background:linear-gradient(160deg,#1a0a0a 0%,#2a1010 40%,#1F1F1F 100%);padding:7rem 2rem 5rem;text-align:center;position:relative;overflow:hidden}
-.hero::before{content:'';position:absolute;top:-200px;left:50%;transform:translateX(-50%);width:700px;height:500px;border-radius:50%;background:radial-gradient(circle,rgba(239,68,68,0.1) 0%,transparent 70%);pointer-events:none}
-.hero-inner{max-width:780px;margin:0 auto;position:relative;z-index:1}
-.hero-badge{display:inline-flex;align-items:center;gap:0.5rem;background:var(--red-dim);border:1px solid rgba(239,68,68,0.3);border-radius:4px;padding:0.35rem 1rem;font-size:0.75rem;font-weight:700;color:var(--red);margin-bottom:1.25rem;text-transform:uppercase;letter-spacing:0.06em;font-family:'Barlow Condensed',sans-serif}
-.hero h1{font-size:clamp(2.2rem,5vw,3.5rem);font-weight:900;line-height:1.1;font-family:'Barlow Condensed',sans-serif;margin-bottom:1.25rem}
-.hero h1 span{color:var(--red)}
-.hero p{font-size:1.05rem;color:var(--text2);max-width:660px;margin:0 auto;line-height:1.8}
+/* ── HERO ── */
+.hero{background:linear-gradient(160deg,#0d0505 0%,#1a0808 40%,#0a0a0a 100%);padding:7rem 5% 5rem;text-align:center;position:relative;overflow:hidden;}
+.hero::before{content:'';position:absolute;top:-200px;left:50%;transform:translateX(-50%);width:700px;height:500px;border-radius:50%;background:radial-gradient(circle,rgba(192,57,43,0.12) 0%,transparent 70%);pointer-events:none;}
+.noise-overlay{position:absolute;inset:0;opacity:.04;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");background-size:200px;pointer-events:none;}
+.hero-inner{max-width:780px;margin:0 auto;position:relative;z-index:1;}
+.hero-badge{display:inline-flex;align-items:center;gap:.5rem;background:rgba(192,57,43,0.12);border:1px solid rgba(192,57,43,0.3);border-radius:4px;padding:.35rem 1rem;font-size:.75rem;font-weight:700;color:var(--red);margin-bottom:1.25rem;text-transform:uppercase;letter-spacing:.06em;font-family:'Barlow Condensed',sans-serif;}
+.hero h1{font-family:'Bebas Neue',sans-serif;font-size:clamp(2.5rem,6vw,4.5rem);line-height:1.05;margin-bottom:1.25rem;letter-spacing:1px;}
+.hero h1 span{color:var(--red);}
+.hero p{font-size:1.05rem;color:var(--muted);max-width:660px;margin:0 auto;line-height:1.8;}
 
-/* SECTIONS */
-section{padding:5rem 2rem}
-.section-inner{max-width:1200px;margin:0 auto}
-.section-badge{display:inline-flex;align-items:center;gap:0.5rem;background:var(--red-dim);border:1px solid rgba(239,68,68,0.3);border-radius:4px;padding:0.3rem 0.9rem;font-size:0.75rem;font-weight:700;color:var(--red);margin-bottom:1rem;text-transform:uppercase;letter-spacing:0.06em;font-family:'Barlow Condensed',sans-serif}
-.section-title{font-size:clamp(1.8rem,3vw,2.8rem);font-weight:900;color:var(--text);font-family:'Barlow Condensed',sans-serif;line-height:1.1}
-.section-title span{color:var(--red)}
-.section-sub{font-size:0.95rem;color:var(--text2);margin:0.6rem 0 0;max-width:560px;line-height:1.7}
+/* ── SECTIONS ── */
+section{padding:80px 5%;}
+.section-inner{max-width:1200px;margin:0 auto;}
+.section-label{font-size:.75rem;font-weight:700;letter-spacing:2px;text-transform:uppercase;color:var(--gold);margin-bottom:.75rem;}
+.section-title{font-family:'Barlow Condensed',sans-serif;font-size:clamp(1.8rem,3.5vw,2.8rem);font-weight:900;line-height:1.1;margin-bottom:1rem;}
+.section-title span{color:var(--red);}
+.section-sub{font-size:.95rem;color:var(--muted);max-width:560px;line-height:1.7;}
+.btn-primary{display:inline-flex;align-items:center;gap:.5rem;padding:.85rem 1.8rem;border-radius:8px;background:var(--red);color:#fff;font-size:.9rem;font-weight:700;transition:all .2s;box-shadow:0 4px 16px rgba(192,57,43,0.3);}
+.btn-primary:hover{background:var(--red-light);transform:translateY(-2px);}
 
-/* MISSION */
-#mission{background:var(--bg2)}
-.mission-grid{display:grid;grid-template-columns:1fr 1fr;gap:4rem;align-items:center}
-.mission-img{border-radius:12px;overflow:hidden;border:2px solid var(--border2);aspect-ratio:1;display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,var(--bg3),var(--bg4));box-shadow:var(--shadow2)}
-.mission-img img{width:75%;height:75%;object-fit:contain}
-.mission-text p{font-size:0.97rem;color:var(--text2);line-height:1.85;margin-bottom:1.25rem}
-.mission-text p:last-of-type{margin-bottom:1.75rem}
-.btn-primary{display:inline-flex;align-items:center;gap:0.5rem;padding:0.78rem 1.6rem;border-radius:6px;background:var(--red);color:#fff;font-size:0.9rem;font-weight:700;text-decoration:none;transition:all 0.2s;box-shadow:0 4px 16px rgba(239,68,68,0.3);font-family:'Barlow',sans-serif}
-.btn-primary:hover{background:var(--red2);transform:translateY(-1px)}
+/* ── MISSION ── */
+#mission{background:var(--surface);}
+.mission-grid{display:grid;grid-template-columns:1fr 1fr;gap:4rem;align-items:center;}
+.mission-img{border-radius:14px;overflow:hidden;border:1px solid rgba(255,255,255,0.1);aspect-ratio:1;display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,#1a1a1a,#222);box-shadow:0 20px 60px rgba(0,0,0,0.5);}
+.mission-img img{width:70%;height:70%;object-fit:contain;}
+.mission-text p{font-size:.97rem;color:var(--muted);line-height:1.85;margin-bottom:1.25rem;}
+.mission-text p:last-of-type{margin-bottom:1.75rem;}
 
-/* STATS */
-#stats{background:var(--bg)}
-.stats-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:2rem;max-width:1000px;margin:0 auto}
-.stat-card{border-left:3px solid rgba(239,68,68,0.3);padding-left:1.25rem;transition:all 0.3s}
-.stat-card:hover{border-left-color:var(--red);transform:translateX(5px)}
-.stat-num{font-size:3rem;font-weight:900;color:var(--red);font-family:'Barlow Condensed',sans-serif;line-height:1;margin-bottom:0.4rem}
-.stat-label{font-size:0.78rem;color:var(--text3);text-transform:uppercase;letter-spacing:0.05em;line-height:1.4}
+/* ── STATS ── */
+#stats{background:var(--bg);}
+.stats-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:2rem;max-width:1000px;margin:3rem auto 0;}
+.stat-card{border-left:3px solid rgba(192,57,43,0.3);padding-left:1.25rem;transition:all .3s;}
+.stat-card:hover{border-left-color:var(--red);transform:translateX(5px);}
+.stat-num{font-family:'Bebas Neue',sans-serif;font-size:3rem;line-height:1;color:var(--red);margin-bottom:.4rem;}
+.stat-label{font-size:.78rem;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;line-height:1.4;}
 
-/* WHO WE SERVE */
-#serve{background:var(--bg2)}
-.serve-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1rem;margin-top:2.5rem}
-.serve-card{background:var(--bg);border:1.5px solid var(--border);border-radius:var(--r2);padding:1.5rem;transition:all 0.25s;box-shadow:var(--shadow);text-align:center}
-.serve-card:hover{border-color:var(--red);transform:translateY(-5px);box-shadow:var(--shadow2)}
-.serve-icon{font-size:2rem;margin-bottom:0.75rem;display:block}
-.serve-title{font-weight:800;color:var(--text);font-size:1rem;font-family:'Barlow',sans-serif;margin-bottom:0.3rem}
-.serve-desc{font-size:0.8rem;color:var(--text2);line-height:1.6}
+/* ── WHO WE SERVE ── */
+#serve{background:var(--surface);}
+.serve-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1rem;margin-top:2.5rem;}
+.serve-card{background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);padding:1.5rem;transition:all .25s;text-align:center;}
+.serve-card:hover{border-color:var(--red);transform:translateY(-5px);box-shadow:0 12px 40px rgba(0,0,0,0.4);}
+.serve-icon{font-size:2rem;margin-bottom:.75rem;display:block;}
+.serve-title{font-weight:800;color:var(--text);font-size:1rem;margin-bottom:.3rem;}
+.serve-desc{font-size:.8rem;color:var(--muted);line-height:1.6;}
+.serve-note{margin-top:2rem;padding:1.25rem 1.75rem;background:rgba(249,115,22,0.06);border:1px solid rgba(249,115,22,0.2);border-radius:var(--radius);text-align:center;}
+.serve-note p{font-size:.92rem;color:var(--muted);}
+.serve-note a{color:var(--gold);font-weight:700;}
 
-/* WHAT WE DO */
-#whatwedo{background:var(--bg)}
-.services-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1.5rem;margin-top:2.5rem}
-.svc-card{background:var(--bg2);border:1.5px solid var(--border);border-radius:var(--r2);padding:1.75rem;transition:all 0.25s;box-shadow:var(--shadow)}
-.svc-card:hover{border-color:var(--red);transform:translateY(-4px);box-shadow:var(--shadow2)}
-.svc-card h3{font-size:1.15rem;font-weight:800;color:var(--text);margin-bottom:1rem;font-family:'Barlow',sans-serif;display:flex;align-items:center;gap:0.5rem}
-.svc-card ul{list-style:none;display:flex;flex-direction:column;gap:0.5rem}
-.svc-card li{font-size:0.85rem;color:var(--text2);padding-left:1.1rem;position:relative}
-.svc-card li::before{content:'→';position:absolute;left:0;color:var(--red);font-weight:900;font-size:0.8rem}
+/* ── WHAT WE DO ── */
+#whatwedo{background:var(--bg);}
+.services-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1.5rem;margin-top:2.5rem;}
+.svc-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.75rem;transition:all .25s;}
+.svc-card:hover{border-color:rgba(192,57,43,0.35);transform:translateY(-4px);}
+.svc-card h3{font-size:1.1rem;font-weight:800;margin-bottom:1rem;display:flex;align-items:center;gap:.5rem;}
+.svc-card ul{list-style:none;display:flex;flex-direction:column;gap:.5rem;}
+.svc-card li{font-size:.85rem;color:var(--muted);padding-left:1.1rem;position:relative;}
+.svc-card li::before{content:'→';position:absolute;left:0;color:var(--red);font-weight:900;font-size:.8rem;}
 
-/* VALUES */
-#values{background:var(--bg2)}
-.values-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.25rem;margin-top:2.5rem}
-.value-card{background:var(--bg);border:1.5px solid var(--border);border-radius:var(--r2);padding:1.75rem;transition:all 0.25s;box-shadow:var(--shadow)}
-.value-card:hover{border-color:var(--red);transform:translateY(-4px);box-shadow:var(--shadow2)}
-.value-icon{width:48px;height:48px;border-radius:8px;background:var(--red-dim);border:1px solid rgba(239,68,68,0.2);display:flex;align-items:center;justify-content:center;font-size:1.3rem;margin-bottom:1rem}
-.value-card h3{font-weight:800;color:var(--text);font-size:1rem;margin-bottom:0.4rem;font-family:'Barlow',sans-serif}
-.value-card p{font-size:0.83rem;color:var(--text2);line-height:1.65}
+/* ── VALUES ── */
+#values{background:var(--surface);}
+.values-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.25rem;margin-top:2.5rem;}
+.value-card{background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);padding:1.75rem;transition:all .25s;}
+.value-card:hover{border-color:rgba(192,57,43,0.35);transform:translateY(-4px);}
+.value-icon{width:48px;height:48px;border-radius:8px;background:rgba(192,57,43,0.1);border:1px solid rgba(192,57,43,0.2);display:flex;align-items:center;justify-content:center;font-size:1.3rem;margin-bottom:1rem;}
+.value-card h3{font-weight:800;font-size:1rem;margin-bottom:.4rem;}
+.value-card p{font-size:.83rem;color:var(--muted);line-height:1.65;}
 
-/* CTA */
-#cta{background:linear-gradient(160deg,#1a0a0a 0%,#2a1010 40%,#1F1F1F 100%);text-align:center;position:relative;overflow:hidden}
-#cta::before{content:'';position:absolute;top:-200px;left:50%;transform:translateX(-50%);width:800px;height:500px;border-radius:50%;background:radial-gradient(circle,rgba(239,68,68,0.1) 0%,transparent 70%);pointer-events:none}
-.cta-inner{max-width:620px;margin:0 auto;position:relative;z-index:1}
-.cta-logo{width:72px;height:72px;border-radius:12px;margin:0 auto 1.5rem;overflow:hidden;border:2px solid rgba(255,255,255,0.12);background:rgba(255,255,255,0.07);display:flex;align-items:center;justify-content:center}
-.cta-logo img{width:65%;height:65%;object-fit:contain}
-.cta-inner h2{font-size:clamp(2rem,4vw,3rem);font-weight:900;color:var(--text);font-family:'Barlow Condensed',sans-serif;line-height:1.1;margin-bottom:0.75rem}
-.cta-inner h2 span{color:var(--red)}
-.cta-inner p{font-size:0.95rem;color:var(--text2);margin-bottom:2rem;line-height:1.75}
-.cta-btns{display:flex;gap:1rem;justify-content:center;flex-wrap:wrap}
-.btn-white{padding:0.9rem 2rem;border-radius:6px;background:var(--text);color:#1F1F1F;font-size:0.92rem;font-weight:700;text-decoration:none;display:flex;align-items:center;gap:0.5rem;transition:all 0.25s;font-family:'Barlow',sans-serif}
-.btn-white:hover{background:#fff;transform:translateY(-2px)}
+/* ── CTA ── */
+#cta{background:linear-gradient(160deg,#0d0505 0%,#1a0808 40%,#0a0a0a 100%);text-align:center;position:relative;overflow:hidden;}
+#cta::before{content:'';position:absolute;top:-200px;left:50%;transform:translateX(-50%);width:800px;height:500px;border-radius:50%;background:radial-gradient(circle,rgba(192,57,43,0.1) 0%,transparent 70%);pointer-events:none;}
+.cta-inner{max-width:620px;margin:0 auto;position:relative;z-index:1;}
+.cta-logo{width:72px;height:72px;border-radius:12px;margin:0 auto 1.5rem;overflow:hidden;border:1px solid rgba(255,255,255,0.1);background:rgba(255,255,255,0.05);display:flex;align-items:center;justify-content:center;}
+.cta-logo img{width:65%;height:65%;object-fit:contain;}
+.cta-inner h2{font-family:'Bebas Neue',sans-serif;font-size:clamp(2.2rem,5vw,3.5rem);line-height:1.1;margin-bottom:.75rem;letter-spacing:1px;}
+.cta-inner h2 span{color:var(--red);}
+.cta-inner p{font-size:.95rem;color:var(--muted);margin-bottom:2rem;line-height:1.75;}
+.cta-btns{display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;}
+.btn-white{padding:.9rem 2rem;border-radius:8px;background:var(--text);color:#0a0a0a;font-size:.9rem;font-weight:700;display:inline-flex;align-items:center;gap:.5rem;transition:all .25s;}
+.btn-white:hover{background:#fff;transform:translateY(-2px);}
 
-/* FOOTER */
-footer{background:var(--bg2);border-top:1px solid var(--border);padding:2rem}
-.footer-inner{max-width:1200px;margin:0 auto;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem}
-.footer-copy{font-size:0.78rem;color:var(--text3)}
-.fsoc{width:34px;height:34px;border-radius:6px;background:var(--bg3);border:1px solid var(--border2);color:var(--text2);display:flex;align-items:center;justify-content:center;text-decoration:none;font-size:0.85rem;transition:all 0.2s}
-.fsoc:hover{border-color:var(--red);color:var(--red)}
+/* ── FOOTER ── */
+footer{background:var(--surface);border-top:1px solid var(--border);padding:60px 5% 30px;}
+.footer-inner{max-width:1280px;margin:0 auto;}
+.footer-top{display:grid;grid-template-columns:1.5fr 1fr 1fr;gap:2.5rem;margin-bottom:3rem;}
+.footer-brand-logo{display:flex;align-items:center;gap:.6rem;margin-bottom:.75rem;}
+.footer-brand-logo img{height:36px;width:auto;}
+.footer-brand-logo-text{font-family:'Barlow Condensed',sans-serif;font-weight:900;font-size:1.1rem;letter-spacing:.05em;}
+.footer-brand p{font-size:.85rem;color:var(--muted);line-height:1.6;max-width:240px;}
+.footer-col h4{font-size:.75rem;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:var(--muted);margin-bottom:1rem;}
+.footer-col ul{list-style:none;display:flex;flex-direction:column;gap:.6rem;}
+.footer-col a{font-size:.88rem;color:var(--muted);transition:color .2s;}
+.footer-col a:hover{color:var(--text);}
+.footer-col span{font-size:.88rem;color:var(--muted);}
+.footer-bottom{border-top:1px solid var(--border);padding-top:1.5rem;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem;}
+.footer-bottom p{font-size:.8rem;color:var(--muted);}
+.footer-social{display:flex;gap:.6rem;}
+.fsoc{width:34px;height:34px;border-radius:6px;background:var(--surface2);border:1px solid var(--border);color:var(--muted);display:flex;align-items:center;justify-content:center;text-decoration:none;transition:all .2s;}
+.fsoc:hover{border-color:var(--red);}
 
-/* REVEAL */
-.reveal{opacity:0;transform:translateY(28px);transition:opacity 0.65s ease,transform 0.65s ease}
-.reveal.in{opacity:1;transform:none}
+/* ── REVEAL ── */
+.reveal{opacity:0;transform:translateY(28px);transition:opacity .65s ease,transform .65s ease;}
+.reveal.in{opacity:1;transform:none;}
 
-/* RESPONSIVE */
+/* ── RESPONSIVE ── */
 @media(max-width:1024px){
-  .stats-grid{grid-template-columns:repeat(2,1fr)}
-  .serve-grid{grid-template-columns:repeat(2,1fr)}
-  .values-grid{grid-template-columns:repeat(2,1fr)}
-  .mission-grid{grid-template-columns:1fr;gap:2rem}
-  .mission-img{max-width:340px;margin:0 auto}
+  .stats-grid{grid-template-columns:repeat(2,1fr);}
+  .serve-grid{grid-template-columns:repeat(2,1fr);}
+  .values-grid{grid-template-columns:repeat(2,1fr);}
+  .mission-grid{grid-template-columns:1fr;gap:2rem;}
+  .mission-img{max-width:340px;margin:0 auto;}
+  .footer-top{grid-template-columns:1fr 1fr;}
 }
 @media(max-width:768px){
-  nav{padding:0 1rem;height:60px}
-  .nav-links,.nav-right{display:none}
-  .hamburger{display:flex}
-  .mobile-menu{top:60px}
-  .nav-logo img{height:34px}
-  .nav-logo-text{font-size:0.85rem}
-  section{padding:3.5rem 1.2rem}
-  .hero{padding:5.5rem 1.5rem 3.5rem}
-  .stats-grid{grid-template-columns:repeat(2,1fr);gap:1.5rem}
-  .serve-grid{grid-template-columns:repeat(2,1fr)}
-  .services-grid{grid-template-columns:1fr}
-  .values-grid{grid-template-columns:1fr}
-  .cta-btns{flex-direction:column;align-items:center}
-  .btn-white,.btn-primary{width:100%;max-width:320px;justify-content:center}
+  nav{padding:0 4%;}
+  .nav-links{display:none;}
+  .nav-hamburger{display:flex;}
+  section{padding:60px 4%;}
+  .hero{padding:6rem 4% 4rem;}
+  .stats-grid{grid-template-columns:repeat(2,1fr);gap:1.5rem;}
+  .serve-grid{grid-template-columns:repeat(2,1fr);}
+  .services-grid{grid-template-columns:1fr;}
+  .values-grid{grid-template-columns:1fr;}
+  .cta-btns{flex-direction:column;align-items:center;}
+  .btn-white,.btn-primary{width:100%;max-width:320px;justify-content:center;}
+  .footer-top{grid-template-columns:1fr 1fr;gap:1.5rem;}
+  .footer-bottom{flex-direction:column;text-align:center;}
 }
 @media(max-width:480px){
-  .serve-grid{grid-template-columns:1fr}
-  .stats-grid{grid-template-columns:1fr}
+  .serve-grid{grid-template-columns:1fr;}
+  .stats-grid{grid-template-columns:1fr;}
+  .footer-top{grid-template-columns:1fr;}
 }
 </style>
 </head>
@@ -168,31 +180,32 @@ footer{background:var(--bg2);border-top:1px solid var(--border);padding:2rem}
 
 <!-- NAV -->
 <nav>
-  <div class="nav-inner">
-    <a href="index.html" class="nav-logo">
-      <img src="https://storage.googleapis.com/msgsndr/kfZT6c91jZcZU6PUztl8/media/69387c0a578cc7a588bf9199.png" alt="Contractor Arsenal">
-      <span class="nav-logo-text">Contractor Arsenal</span>
-    </a>
-    <ul class="nav-links">
-      <li><a href="index.html">Home</a></li>
-      <li><a href="about.html" class="active">About</a></li>
-    </ul>
-    <div class="nav-right">
-      <a href="apply.html" class="nav-btn-primary">Apply Now ↗</a>
-    </div>
-    <button class="hamburger" id="hamburger" onclick="toggleMenu()"><span></span><span></span><span></span></button>
+  <a href="index.html" class="nav-logo">
+    <img src="https://storage.googleapis.com/msgsndr/kfZT6c91jZcZU6PUztl8/media/69387c0a578cc7a588bf9199.png" alt="Contractor Arsenal">
+    <span class="nav-logo-text">Contractor Arsenal</span>
+  </a>
+  <div class="nav-links">
+    <a href="index.html">Home</a>
+    <a href="about.html" class="active">About</a>
+    <a href="arsenal.html">Arsenal 001</a>
+    <a href="apply.html" class="nav-cta">Apply Now</a>
   </div>
+  <button class="nav-hamburger" onclick="toggleMenu()" aria-label="Menu">
+    <span></span><span></span><span></span>
+  </button>
 </nav>
-<div class="mobile-menu" id="mobileMenu">
-  <a href="index.html" onclick="closeMenu()">🏠 Home</a>
-  <a href="about.html" onclick="closeMenu()">ℹ️ About</a>
-  <a href="apply.html" onclick="closeMenu()">📋 Apply Now</a>
+<div class="nav-mobile" id="navMobile">
+  <a href="index.html" onclick="closeMenu()">Home</a>
+  <a href="about.html" onclick="closeMenu()">About</a>
+  <a href="arsenal.html" onclick="closeMenu()">Arsenal 001</a>
+  <a href="apply.html" onclick="closeMenu()">Apply Now</a>
 </div>
 
 <!-- HERO -->
 <section class="hero">
+  <div class="noise-overlay"></div>
   <div class="hero-inner reveal">
-    <div class="hero-badge">⚡ Our Story</div>
+    <div class="hero-badge">Our Story</div>
     <h1>Built for Contractors<br><span>Who Want to Win</span></h1>
     <p>Contractor Arsenal was built because too many good tradespeople were losing jobs to competitors with better-looking websites. We fix that. We understand the trades, we know what converts, and we build sites that work.</p>
   </div>
@@ -204,16 +217,16 @@ footer{background:var(--bg2);border-top:1px solid var(--border);padding:2rem}
     <div class="mission-grid">
       <div class="reveal">
         <div class="mission-img">
-          <img src="https://storage.googleapis.com/msgsndr/kfZT6c91jZcZU6PUztl8/media/69387c0a578cc7a588bf9199.png" alt="Contractor Arsenal">
+          <img src="https://storage.googleapis.com/msgsndr/kfZT6c91jZcZU6PUztl8/media/69387c0a578cc7a588bf9199.png" alt="Contractor Arsenal Logo">
         </div>
       </div>
-      <div class="reveal" style="transition-delay:0.15s">
-        <div class="section-badge">Our Mission</div>
+      <div class="reveal" style="transition-delay:.15s">
+        <div class="section-label">Our Mission</div>
         <h2 class="section-title">We Help Contractors <span>Dominate</span> Their Local Market</h2>
         <div class="mission-text" style="margin-top:1.25rem">
-          <p>Our mission is simple: build contractor websites that generate real leads and real revenue. Not pretty templates that sit idle   but active, ranking, converting machines that work while you're on the job site.</p>
-          <p>We've worked with painters, roofers, landscapers, and remodelers across the country. We know what homeowners search for, what makes them call, and what makes them bounce. Every decision we make is built around that knowledge.</p>
-          <a href="apply.html" class="btn-primary">Apply Now   60 Seconds →</a>
+          <p>Our mission is simple: build contractor websites that generate real leads and real revenue. Not pretty templates that sit idle — but active, ranking, converting machines that work while you're on the job site.</p>
+          <p>We've worked with painters, roofers, landscapers, remodelers, HVAC techs, plumbers, and more across the country. We know what homeowners search for, what makes them call, and what makes them bounce.</p>
+          <a href="apply.html" class="btn-primary">Apply Now — 60 Seconds →</a>
         </div>
       </div>
     </div>
@@ -224,10 +237,10 @@ footer{background:var(--bg2);border-top:1px solid var(--border);padding:2rem}
 <section id="stats">
   <div class="section-inner" style="text-align:center">
     <div class="reveal">
-      <div class="section-badge" style="display:inline-flex">By the Numbers</div>
-      <h2 class="section-title" style="text-align:center;margin-top:0.5rem">Proven <span>Results</span></h2>
+      <div class="section-label" style="display:inline-block">By the Numbers</div>
+      <h2 class="section-title" style="margin-top:.5rem">Proven <span>Results</span></h2>
     </div>
-    <div class="stats-grid reveal" style="transition-delay:0.1s;margin-top:3rem">
+    <div class="stats-grid reveal" style="transition-delay:.1s">
       <div class="stat-card">
         <div class="stat-num">$850K+</div>
         <div class="stat-label">Revenue generated for clients</div>
@@ -252,31 +265,54 @@ footer{background:var(--bg2);border-top:1px solid var(--border);padding:2rem}
 <section id="serve">
   <div class="section-inner">
     <div class="reveal" style="text-align:center">
-      <div class="section-badge" style="display:inline-flex">Industries</div>
-      <h2 class="section-title" style="text-align:center;margin-top:0.5rem">Who We <span>Serve</span></h2>
-      <p style="font-size:0.95rem;color:var(--text2);text-align:center;margin:0.6rem auto 0;max-width:480px">We build for contractors who are serious about growth. If you're in the trades and want more inbound leads, we can help.</p>
+      <div class="section-label" style="display:inline-block">Industries</div>
+      <h2 class="section-title" style="text-align:center;margin-top:.5rem">Built for <span>Every</span> Contractor</h2>
+      <p style="font-size:.95rem;color:var(--muted);text-align:center;margin:.6rem auto 0;max-width:520px">If you do residential or commercial work, we build for you. We know the trades, the keywords, and what converts in your market.</p>
     </div>
-    <div class="serve-grid reveal" style="transition-delay:0.1s">
+    <div class="serve-grid reveal" style="transition-delay:.1s">
       <div class="serve-card">
         <span class="serve-icon">🎨</span>
         <div class="serve-title">Painters</div>
-        <div class="serve-desc">Interior, exterior, cabinet refinishing. We know the painting industry inside out.</div>
+        <div class="serve-desc">Interior, exterior, cabinet refinishing. We rank you for high-value local jobs.</div>
       </div>
       <div class="serve-card">
         <span class="serve-icon">🏠</span>
         <div class="serve-title">Roofers</div>
-        <div class="serve-desc">Storm damage pages, insurance claims info, and financing pages that convert.</div>
+        <div class="serve-desc">Storm damage pages, insurance info, and financing that converts.</div>
       </div>
       <div class="serve-card">
         <span class="serve-icon">🌿</span>
         <div class="serve-title">Landscapers</div>
-        <div class="serve-desc">Seasonal service pages, lawn care, hardscaping   built to rank year-round.</div>
+        <div class="serve-desc">Seasonal service pages built to rank and convert year-round.</div>
       </div>
       <div class="serve-card">
         <span class="serve-icon">🔨</span>
         <div class="serve-title">Remodelers</div>
-        <div class="serve-desc">Kitchen, bath, whole-home remodeling sites with before/after galleries and forms.</div>
+        <div class="serve-desc">Kitchen, bath, whole-home with before/after galleries and forms.</div>
       </div>
+      <div class="serve-card">
+        <span class="serve-icon">❄️</span>
+        <div class="serve-title">HVAC</div>
+        <div class="serve-desc">Own the seasonal search spikes. More installs, more service calls.</div>
+      </div>
+      <div class="serve-card">
+        <span class="serve-icon">🔧</span>
+        <div class="serve-title">Plumbers</div>
+        <div class="serve-desc">Emergency, install, remodel. Rank when homeowners need help fast.</div>
+      </div>
+      <div class="serve-card">
+        <span class="serve-icon">⚡</span>
+        <div class="serve-title">Electricians</div>
+        <div class="serve-desc">Panels, EV chargers, residential and commercial electrical work.</div>
+      </div>
+      <div class="serve-card">
+        <span class="serve-icon">🏗️</span>
+        <div class="serve-title">General Contractors</div>
+        <div class="serve-desc">New builds, additions, renovations. A site that reflects your scale.</div>
+      </div>
+    </div>
+    <div class="serve-note">
+      <p>Don't see your trade? <a href="apply.html">Apply anyway</a> — if you do residential or commercial work, we can build for you.</p>
     </div>
   </div>
 </section>
@@ -285,15 +321,15 @@ footer{background:var(--bg2);border-top:1px solid var(--border);padding:2rem}
 <section id="whatwedo">
   <div class="section-inner">
     <div class="reveal" style="text-align:center">
-      <div class="section-badge" style="display:inline-flex">Services</div>
-      <h2 class="section-title" style="text-align:center;margin-top:0.5rem">What We <span>Build</span></h2>
-      <p style="font-size:0.95rem;color:var(--text2);text-align:center;margin:0.6rem auto 0;max-width:500px">Every site we build is purpose-built to rank locally and turn visitors into calls and quote requests.</p>
+      <div class="section-label" style="display:inline-block">Services</div>
+      <h2 class="section-title" style="text-align:center;margin-top:.5rem">What We <span>Build</span></h2>
+      <p style="font-size:.95rem;color:var(--muted);text-align:center;margin:.6rem auto 0;max-width:500px">Every site we build is purpose-built to rank locally and turn visitors into calls and quote requests.</p>
     </div>
-    <div class="services-grid reveal" style="transition-delay:0.1s">
+    <div class="services-grid reveal" style="transition-delay:.1s">
       <div class="svc-card">
         <h3>🎨 Website Design &amp; Development</h3>
         <ul>
-          <li>Custom contractor-specific design   no templates</li>
+          <li>Custom contractor-specific design — no templates</li>
           <li>Mobile-first, fast-loading layouts</li>
           <li>Professional copywriting that sells your services</li>
           <li>Before/after photo galleries and video support</li>
@@ -325,9 +361,9 @@ footer{background:var(--bg2);border-top:1px solid var(--border);padding:2rem}
         <ul>
           <li>Unlimited edits during your 30-day launch window</li>
           <li>Post-launch update packages available</li>
-          <li>Hosting recommendations (you own everything)</li>
+          <li>Hosting recommendations — you own everything</li>
           <li>Domain setup assistance</li>
-          <li>Fast response time   we don't ghost clients</li>
+          <li>Fast response time — we don't ghost clients</li>
         </ul>
       </div>
     </div>
@@ -338,14 +374,14 @@ footer{background:var(--bg2);border-top:1px solid var(--border);padding:2rem}
 <section id="values">
   <div class="section-inner">
     <div class="reveal" style="text-align:center">
-      <div class="section-badge" style="display:inline-flex">How We Work</div>
-      <h2 class="section-title" style="text-align:center;margin-top:0.5rem">Our <span>Principles</span></h2>
+      <div class="section-label" style="display:inline-block">How We Work</div>
+      <h2 class="section-title" style="text-align:center;margin-top:.5rem">Our <span>Principles</span></h2>
     </div>
-    <div class="values-grid reveal" style="transition-delay:0.1s">
+    <div class="values-grid reveal" style="transition-delay:.1s">
       <div class="value-card">
         <div class="value-icon">🎯</div>
         <h3>Results Over Aesthetics</h3>
-        <p>A beautiful site that doesn't rank or convert is worthless. We build for leads first, looks second   and we're good at both.</p>
+        <p>A beautiful site that doesn't rank or convert is worthless. We build for leads first, looks second — and we're good at both.</p>
       </div>
       <div class="value-card">
         <div class="value-icon">💬</div>
@@ -363,7 +399,7 @@ footer{background:var(--bg2);border-top:1px solid var(--border);padding:2rem}
         <p>Your domain, your hosting, your site. We don't lock you into proprietary platforms or monthly fees for basic stuff.</p>
       </div>
       <div class="value-card">
-        <div class="value-icon">🏗</div>
+        <div class="value-icon">🏗️</div>
         <h3>Contractor-First Thinking</h3>
         <p>We understand the trades. We know how homeowners search, what makes them trust you, and what makes them call.</p>
       </div>
@@ -378,16 +414,17 @@ footer{background:var(--bg2);border-top:1px solid var(--border);padding:2rem}
 
 <!-- CTA -->
 <section id="cta">
+  <div class="noise-overlay"></div>
   <div class="section-inner">
     <div class="cta-inner reveal">
       <div class="cta-logo">
         <img src="https://storage.googleapis.com/msgsndr/kfZT6c91jZcZU6PUztl8/media/69387c0a578cc7a588bf9199.png" alt="Contractor Arsenal">
       </div>
       <h2>Ready to Get <span>More Calls?</span></h2>
-      <p>Stop losing jobs to competitors with better websites. Apply in 60 seconds   if you're not a fit, we'll tell you upfront.</p>
+      <p>Stop losing jobs to competitors with better websites. Apply in 60 seconds — if you're not a fit, we'll tell you upfront.</p>
       <div class="cta-btns">
-        <a href="apply.html" class="btn-primary">Apply Now   60 Seconds →</a>
-        <a href="index.html" class="btn-white">&#8592; Back to Home</a>
+        <a href="apply.html" class="btn-primary">Apply Now — 60 Seconds →</a>
+        <a href="index.html" class="btn-white">← Back to Home</a>
       </div>
     </div>
   </div>
@@ -396,35 +433,58 @@ footer{background:var(--bg2);border-top:1px solid var(--border);padding:2rem}
 <!-- FOOTER -->
 <footer>
   <div class="footer-inner">
-    <span class="footer-copy">&copy; 2025 Contractor Arsenal. All rights reserved.</span>
-    <a href="https://www.instagram.com/contractorarsenal/" target="_blank" rel="noopener" class="fsoc" title="Instagram">
-      <svg viewBox="0 0 24 24" width="18" height="18" fill="none"><defs><linearGradient id="ig" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#FFDC80"/><stop offset="30%" stop-color="#F77737"/><stop offset="60%" stop-color="#C13584"/><stop offset="100%" stop-color="#515BD4"/></linearGradient></defs><rect x="2" y="2" width="20" height="20" rx="5.5" fill="url(#ig)"/><circle cx="12" cy="12" r="4.2" stroke="#fff" stroke-width="1.8" fill="none"/><circle cx="17.2" cy="6.8" r="1.1" fill="#fff"/></svg>
-    </a>
+    <div class="footer-top">
+      <div class="footer-brand">
+        <div class="footer-brand-logo">
+          <img src="https://storage.googleapis.com/msgsndr/kfZT6c91jZcZU6PUztl8/media/69387c0a578cc7a588bf9199.png" alt="Contractor Arsenal">
+          <span class="footer-brand-logo-text">Contractor Arsenal</span>
+        </div>
+        <p>Done-for-you websites built for contractors who want more local jobs and less tech headaches.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Navigate</h4>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="apply.html">Apply Now</a></li>
+          <li><a href="arsenal.html">Arsenal 001</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Services</h4>
+        <ul>
+          <li><span>Website Design</span></li>
+          <li><span>Local SEO</span></li>
+          <li><span>Copywriting</span></li>
+          <li><span>Mobile Optimization</span></li>
+          <li><span>Ongoing Support</span></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <p>&copy; 2025 Contractor Arsenal. All rights reserved.</p>
+      <div class="footer-social">
+        <a href="https://www.instagram.com/contractorarsenal/" target="_blank" rel="noopener" class="fsoc" title="Instagram">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none"><defs><linearGradient id="ig" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#FFDC80"/><stop offset="30%" stop-color="#F77737"/><stop offset="60%" stop-color="#C13584"/><stop offset="100%" stop-color="#515BD4"/></linearGradient></defs><rect x="2" y="2" width="20" height="20" rx="5.5" fill="url(#ig)"/><circle cx="12" cy="12" r="4.2" stroke="#fff" stroke-width="1.8" fill="none"/><circle cx="17.2" cy="6.8" r="1.1" fill="#fff"/></svg>
+        </a>
+      </div>
+    </div>
   </div>
 </footer>
 
 <script>
-function toggleMenu(){
-  var m=document.getElementById('mobileMenu'),b=document.getElementById('hamburger');
-  var o=m.classList.contains('open');
-  m.classList.toggle('open',!o);b.classList.toggle('open',!o);
-  document.body.style.overflow=o?'':'hidden';
-}
-function closeMenu(){
-  document.getElementById('mobileMenu').classList.remove('open');
-  document.getElementById('hamburger').classList.remove('open');
-  document.body.style.overflow='';
-}
-var io = new IntersectionObserver(function(entries) {
-  entries.forEach(function(e) {
-    if (e.isIntersecting) {
+function toggleMenu(){document.getElementById('navMobile').classList.toggle('open');}
+function closeMenu(){document.getElementById('navMobile').classList.remove('open');}
+var io = new IntersectionObserver(function(entries){
+  entries.forEach(function(e){
+    if(e.isIntersecting){
       var siblings = Array.from(e.target.parentElement.querySelectorAll('.reveal'));
-      setTimeout(function() { e.target.classList.add('in'); }, Math.min(siblings.indexOf(e.target) * 90, 300));
+      setTimeout(function(){e.target.classList.add('in');}, Math.min(siblings.indexOf(e.target)*90,300));
       io.unobserve(e.target);
     }
   });
-}, {threshold:0.08});
-document.querySelectorAll('.reveal').forEach(function(el) { io.observe(el); });
+},{threshold:0.08});
+document.querySelectorAll('.reveal').forEach(function(el){io.observe(el);});
 </script>
 </body>
 </html>

--- a/apply.html
+++ b/apply.html
@@ -3,525 +3,214 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Apply Now | Contractor Arsenal   Websites That Win You More Jobs</title>
+<title>Apply Now | Contractor Arsenal — Websites That Win You More Jobs</title>
 <meta name="description" content="Apply for a Contractor Arsenal website. Fill out the form, pick your budget, and we'll launch your lead-generating site in 48-72 hours.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,400;0,500;0,600;0,700;0,800;0,900;1,700&family=Barlow+Condensed:wght@600;700;800;900&family=Bebas+Neue&display=swap" rel="stylesheet">
 <style>
-*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
-html{scroll-behavior:smooth}
 :root{
-  --bg:#111113;
-  --bg2:#18181b;
-  --bg3:#1e1e22;
-  --bg4:#26262c;
-  --bg5:#2e2e35;
-  --border:rgba(255,255,255,0.07);
-  --border2:rgba(255,255,255,0.14);
-  --border3:rgba(255,255,255,0.22);
-  --red:#EF4444;
-  --red2:#DC2626;
-  --red3:#F87171;
-  --red-dim:rgba(239,68,68,0.1);
-  --red-glow:rgba(239,68,68,0.25);
-  --gold:#F59E0B;
-  --gold2:#FBBF24;
-  --gold-dim:rgba(245,158,11,0.1);
+  --bg:#0a0a0a;--surface:#111111;--surface2:#1a1a1a;
+  --bg2:#111113;--bg3:#18181b;--bg4:#26262c;--bg5:#2e2e35;
+  --border:rgba(255,255,255,0.07);--border2:rgba(255,255,255,0.14);
+  --red:#C0392B;--red-light:#E74C3C;--red2:#a93226;
+  --red-dim:rgba(192,57,43,0.1);--red-glow:rgba(192,57,43,0.25);
+  --gold:#F97316;--gold2:#FB923C;
   --green:#10B981;
-  --text:#F0F0F2;
-  --text2:#A8A8B3;
-  --text3:#66666e;
-  --text4:#3a3a42;
-  --r:8px;--r2:14px;--r3:20px;
+  --text:#f0f0f0;--text2:#A8A8B3;--text3:#66666e;--text4:#3a3a42;
+  --muted:#888;--radius:12px;
 }
-body{font-family:'Barlow',sans-serif;background:var(--bg);color:var(--text);line-height:1.6;overflow-x:hidden}
-::-webkit-scrollbar{width:3px}
-::-webkit-scrollbar-track{background:var(--bg)}
-::-webkit-scrollbar-thumb{background:var(--red);border-radius:4px}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
+html{scroll-behavior:smooth;}
+body{font-family:'Barlow',sans-serif;background:var(--bg);color:var(--text);line-height:1.6;overflow-x:hidden;}
+a{color:inherit;text-decoration:none;}
+::-webkit-scrollbar{width:3px;}
+::-webkit-scrollbar-track{background:var(--bg);}
+::-webkit-scrollbar-thumb{background:var(--red);border-radius:4px;}
 
-/* NOISE OVERLAY */
-body::before{
-  content:'';position:fixed;inset:0;z-index:0;pointer-events:none;
-  background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.04'/%3E%3C/svg%3E");
-  opacity:0.35;
-}
+body::before{content:'';position:fixed;inset:0;z-index:0;pointer-events:none;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.04'/%3E%3C/svg%3E");opacity:0.35;}
 
-/* NAV */
-nav{
-  position:sticky;top:0;z-index:100;
-  background:rgba(17,17,19,0.92);
-  backdrop-filter:blur(20px);
-  border-bottom:1px solid var(--border);
-  height:68px;display:flex;align-items:center;padding:0 2rem;
-}
-.nav-inner{max-width:1100px;margin:0 auto;width:100%;display:flex;align-items:center;gap:2rem}
-.nav-logo{display:flex;align-items:center;gap:0.65rem;text-decoration:none;flex-shrink:0}
-.nav-logo img{height:38px;width:auto}
-.nav-logo-text{font-family:'Barlow Condensed',sans-serif;font-weight:900;font-size:1.05rem;color:var(--text);letter-spacing:0.04em}
-.nav-links{display:flex;gap:0;list-style:none;margin-left:0.5rem}
-.nav-links a{padding:0.5rem 1rem;font-size:0.85rem;color:var(--text3);text-decoration:none;font-weight:700;transition:color 0.2s;font-family:'Barlow Condensed',sans-serif;letter-spacing:0.04em;text-transform:uppercase}
-.nav-links a:hover{color:var(--text)}
-.nav-right{margin-left:auto}
-.nav-cta{
-  padding:0.5rem 1.2rem;border-radius:6px;
-  background:var(--red);color:#fff;
-  font-size:0.8rem;font-weight:800;
-  text-decoration:none;
-  font-family:'Barlow Condensed',sans-serif;
-  letter-spacing:0.06em;text-transform:uppercase;
-  transition:all 0.2s;
-  box-shadow:0 0 0 0 var(--red-glow);
-}
-.nav-cta:hover{background:var(--red2);box-shadow:0 0 20px var(--red-glow)}
-.hamburger{display:none;flex-direction:column;gap:5px;cursor:pointer;padding:8px;margin-left:auto;background:none;border:none}
-.hamburger span{display:block;width:22px;height:2px;background:var(--text);border-radius:2px;transition:all 0.3s}
-.hamburger.open span:nth-child(1){transform:translateY(7px) rotate(45deg)}
-.hamburger.open span:nth-child(2){opacity:0}
-.hamburger.open span:nth-child(3){transform:translateY(-7px) rotate(-45deg)}
-.mobile-menu{display:none;position:fixed;top:68px;left:0;right:0;bottom:0;background:rgba(17,17,19,0.99);z-index:99;flex-direction:column;padding:2rem 1.5rem;gap:0}
-.mobile-menu.open{display:flex}
-.mobile-menu a{padding:1.1rem 0;font-size:1.1rem;font-weight:700;color:var(--text2);text-decoration:none;border-bottom:1px solid var(--border);font-family:'Barlow Condensed',sans-serif;text-transform:uppercase;letter-spacing:0.05em}
-.mobile-menu a:hover{color:var(--red)}
+/* ── NAV ── */
+nav{position:sticky;top:0;z-index:100;background:rgba(10,10,10,0.95);backdrop-filter:blur(20px);border-bottom:1px solid var(--border);height:68px;display:flex;align-items:center;padding:0 5%;}
+.nav-inner{max-width:1100px;margin:0 auto;width:100%;display:flex;align-items:center;gap:2rem;}
+.nav-logo{display:flex;align-items:center;gap:.65rem;}
+.nav-logo img{height:38px;width:auto;}
+.nav-logo-text{font-family:'Barlow Condensed',sans-serif;font-weight:900;font-size:1.05rem;color:var(--text);letter-spacing:.04em;}
+.nav-links{display:flex;gap:0;list-style:none;margin-left:.5rem;}
+.nav-links a{padding:.5rem 1rem;font-size:.82rem;color:var(--text3);font-weight:700;transition:color .2s;font-family:'Barlow Condensed',sans-serif;letter-spacing:.04em;text-transform:uppercase;}
+.nav-links a:hover{color:var(--text);}
+.nav-right{margin-left:auto;}
+.nav-cta{padding:.5rem 1.2rem;border-radius:6px;background:var(--red);color:#fff;font-size:.8rem;font-weight:800;text-decoration:none;font-family:'Barlow Condensed',sans-serif;letter-spacing:.06em;text-transform:uppercase;transition:all .2s;}
+.nav-cta:hover{background:var(--red-light);}
+.hamburger{display:none;flex-direction:column;gap:5px;cursor:pointer;padding:8px;margin-left:auto;background:none;border:none;}
+.hamburger span{display:block;width:22px;height:2px;background:var(--text);border-radius:2px;transition:all .3s;}
+.hamburger.open span:nth-child(1){transform:translateY(7px) rotate(45deg);}
+.hamburger.open span:nth-child(2){opacity:0;}
+.hamburger.open span:nth-child(3){transform:translateY(-7px) rotate(-45deg);}
+.mobile-menu{display:none;position:fixed;top:68px;left:0;right:0;bottom:0;background:rgba(10,10,10,.99);z-index:99;flex-direction:column;padding:2rem 1.5rem;gap:0;}
+.mobile-menu.open{display:flex;}
+.mobile-menu a{padding:1.1rem 0;font-size:1.1rem;font-weight:700;color:var(--text2);border-bottom:1px solid var(--border);font-family:'Barlow Condensed',sans-serif;text-transform:uppercase;letter-spacing:.05em;}
+.mobile-menu a:hover{color:var(--red);}
 
-/* HERO */
-.hero{
-  position:relative;overflow:hidden;
-  padding:5rem 2rem 3rem;
-  background:radial-gradient(ellipse 900px 500px at 50% -100px, rgba(239,68,68,0.12) 0%, transparent 70%), var(--bg);
-  text-align:center;
-}
-.hero-ticker{
-  display:inline-flex;align-items:center;gap:0.6rem;
-  background:rgba(239,68,68,0.08);
-  border:1px solid rgba(239,68,68,0.25);
-  border-radius:3px;
-  padding:0.3rem 1rem;
-  font-size:0.7rem;font-weight:800;
-  color:var(--red);
-  text-transform:uppercase;letter-spacing:0.1em;
-  font-family:'Barlow Condensed',sans-serif;
-  margin-bottom:1.5rem;
-}
-.ticker-dot{width:6px;height:6px;border-radius:50%;background:var(--red);animation:pulse 2s infinite}
-@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:0.4;transform:scale(0.8)}}
-.hero h1{
-  font-family:'Bebas Neue',sans-serif;
-  font-size:clamp(3.5rem,9vw,7rem);
-  line-height:0.95;
-  letter-spacing:0.02em;
-  color:var(--text);
-  margin-bottom:1.25rem;
-}
-.hero h1 .line2{
-  color:var(--red);
-  -webkit-text-stroke:2px var(--red);
-  display:block;
-}
-.hero-sub{
-  font-size:1rem;color:var(--text2);
-  max-width:520px;margin:0 auto 2rem;
-  line-height:1.8;
-}
-.hero-sub strong{color:var(--text);font-weight:700}
-.hero-chips{display:flex;gap:0.6rem;justify-content:center;flex-wrap:wrap}
-.hero-chip{
-  display:flex;align-items:center;gap:0.4rem;
-  padding:0.35rem 0.85rem;
-  border-radius:4px;
-  background:var(--bg3);
-  border:1px solid var(--border2);
-  font-size:0.75rem;font-weight:700;
-  color:var(--text2);
-  font-family:'Barlow Condensed',sans-serif;
-  letter-spacing:0.04em;
-}
-.hero-chip .dot{width:5px;height:5px;border-radius:50%;background:var(--green)}
+/* ── HERO ── */
+.hero{position:relative;overflow:hidden;padding:5rem 2rem 3rem;background:radial-gradient(ellipse 900px 500px at 50% -100px,rgba(192,57,43,0.12) 0%,transparent 70%),var(--bg);text-align:center;}
+.hero-ticker{display:inline-flex;align-items:center;gap:.6rem;background:rgba(192,57,43,0.08);border:1px solid rgba(192,57,43,0.25);border-radius:3px;padding:.3rem 1rem;font-size:.7rem;font-weight:800;color:var(--red);text-transform:uppercase;letter-spacing:.1em;font-family:'Barlow Condensed',sans-serif;margin-bottom:1.5rem;}
+.ticker-dot{width:6px;height:6px;border-radius:50%;background:var(--red);animation:pulse 2s infinite;}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1);}50%{opacity:.4;transform:scale(.8);}}
+.hero h1{font-family:'Bebas Neue',sans-serif;font-size:clamp(3.5rem,9vw,7rem);line-height:.95;letter-spacing:.02em;color:var(--text);margin-bottom:1.25rem;}
+.hero h1 .line2{color:var(--red);-webkit-text-stroke:2px var(--red);display:block;}
+.hero-sub{font-size:1rem;color:var(--text2);max-width:520px;margin:0 auto 2rem;line-height:1.8;}
+.hero-sub strong{color:var(--text);font-weight:700;}
+.hero-chips{display:flex;gap:.6rem;justify-content:center;flex-wrap:wrap;}
+.hero-chip{display:flex;align-items:center;gap:.4rem;padding:.35rem .85rem;border-radius:4px;background:var(--surface2);border:1px solid var(--border2);font-size:.75rem;font-weight:700;color:var(--text2);font-family:'Barlow Condensed',sans-serif;letter-spacing:.04em;}
+.hero-chip .dot{width:5px;height:5px;border-radius:50%;background:var(--green);}
 
-/* MAIN LAYOUT */
-.main-wrap{max-width:1100px;margin:0 auto;padding:3rem 2rem 6rem;display:grid;grid-template-columns:1fr 440px;gap:3.5rem;align-items:start}
+/* ── LAYOUT ── */
+.main-wrap{max-width:1100px;margin:0 auto;padding:3rem 2rem 6rem;display:grid;grid-template-columns:1fr 440px;gap:3.5rem;align-items:start;}
 
-/* FORM CARD */
-.form-card{
-  background:var(--bg2);
-  border:1.5px solid var(--border2);
-  border-radius:var(--r3);
-  overflow:hidden;
-  box-shadow:0 40px 80px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.04);
-  position:sticky;top:88px;
-}
-.form-card-header{
-  padding:2rem 2rem 1.5rem;
-  border-bottom:1px solid var(--border);
-  background:linear-gradient(135deg, var(--bg3), var(--bg2));
-}
-.form-step-indicator{
-  display:flex;align-items:center;gap:0.5rem;
-  margin-bottom:1.2rem;
-}
-.step-dot{
-  width:28px;height:28px;border-radius:50%;
-  display:flex;align-items:center;justify-content:center;
-  font-size:0.7rem;font-weight:900;
-  font-family:'Barlow Condensed',sans-serif;
-  border:2px solid var(--border2);
-  color:var(--text3);
-  transition:all 0.3s;
-}
-.step-dot.active{background:var(--red);border-color:var(--red);color:#fff;box-shadow:0 0 12px var(--red-glow)}
-.step-dot.done{background:var(--green);border-color:var(--green);color:#fff}
-.step-line{flex:1;height:1px;background:var(--border2)}
-.form-card-title{font-family:'Barlow Condensed',sans-serif;font-size:1.4rem;font-weight:900;color:var(--text);letter-spacing:0.02em}
-.form-card-sub{font-size:0.82rem;color:var(--text3);margin-top:0.3rem}
-.form-body{padding:1.75rem 2rem 2rem}
+/* ── FORM CARD ── */
+.form-card{background:var(--bg3);border:1.5px solid var(--border2);border-radius:20px;overflow:hidden;box-shadow:0 40px 80px rgba(0,0,0,0.6),0 0 0 1px rgba(255,255,255,0.04);position:sticky;top:88px;}
+.form-card-header{padding:2rem 2rem 1.5rem;border-bottom:1px solid var(--border);background:linear-gradient(135deg,var(--bg4),var(--bg3));}
+.form-step-indicator{display:flex;align-items:center;gap:.5rem;margin-bottom:1.2rem;}
+.step-dot{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:.7rem;font-weight:900;font-family:'Barlow Condensed',sans-serif;border:2px solid var(--border2);color:var(--text3);transition:all .3s;}
+.step-dot.active{background:var(--red);border-color:var(--red);color:#fff;box-shadow:0 0 12px var(--red-glow);}
+.step-dot.done{background:var(--green);border-color:var(--green);color:#fff;}
+.step-line{flex:1;height:1px;background:var(--border2);}
+.form-card-title{font-family:'Barlow Condensed',sans-serif;font-size:1.4rem;font-weight:900;color:var(--text);letter-spacing:.02em;}
+.form-card-sub{font-size:.82rem;color:var(--text3);margin-top:.3rem;}
+.form-body{padding:1.75rem 2rem 2rem;}
+.form-row{display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-bottom:1rem;}
+.form-row.solo{grid-template-columns:1fr;}
+.form-field{display:flex;flex-direction:column;gap:.4rem;}
+.form-label{font-size:.68rem;font-weight:800;color:var(--text3);text-transform:uppercase;letter-spacing:.08em;font-family:'Barlow Condensed',sans-serif;}
+.form-input{background:var(--bg4);border:1.5px solid var(--border2);border-radius:8px;padding:.7rem .95rem;font-size:.88rem;color:var(--text);outline:none;font-family:'Barlow',sans-serif;transition:border .2s,box-shadow .2s;width:100%;}
+.form-input::placeholder{color:var(--text4);}
+.form-input:focus{border-color:var(--red);box-shadow:0 0 0 3px rgba(192,57,43,0.1);background:var(--bg5);}
+select.form-input{-webkit-appearance:none;appearance:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' fill='none'%3E%3Cpath stroke='%2366666e' stroke-width='1.5' d='M1 1l4 4 4-4'/%3E%3C/svg%3E");background-repeat:no-repeat;background-position:right 1rem center;cursor:pointer;}
+select.form-input option{background:var(--bg4);color:var(--text);}
+textarea.form-input{resize:vertical;min-height:80px;line-height:1.6;}
+.form-divider{display:flex;align-items:center;gap:.75rem;margin:1.5rem 0 1.25rem;}
+.form-divider span{font-size:.68rem;font-weight:800;color:var(--text3);text-transform:uppercase;letter-spacing:.08em;font-family:'Barlow Condensed',sans-serif;white-space:nowrap;}
+.form-divider::before,.form-divider::after{content:'';flex:1;height:1px;background:var(--border2);}
+.budget-section{margin-bottom:1.25rem;}
+.budget-display{display:flex;align-items:baseline;gap:.5rem;margin-bottom:1rem;}
+.budget-amount{font-family:'Bebas Neue',sans-serif;font-size:3.5rem;line-height:1;color:var(--text);transition:color .3s;}
+.budget-period{font-size:.8rem;color:var(--text3);font-weight:700;padding-bottom:.3rem;}
+.payment-toggle{display:inline-flex;background:var(--bg4);border:1px solid var(--border2);border-radius:6px;padding:3px;margin-bottom:1.25rem;gap:2px;}
+.toggle-btn{padding:.4rem 1rem;border-radius:4px;font-size:.75rem;font-weight:800;font-family:'Barlow Condensed',sans-serif;letter-spacing:.06em;text-transform:uppercase;cursor:pointer;border:none;background:transparent;color:var(--text3);transition:all .2s;}
+.toggle-btn.active{background:var(--red);color:#fff;box-shadow:0 2px 8px rgba(192,57,43,0.3);}
+.slider-wrap{position:relative;padding-bottom:1.75rem;}
+.slider-track{width:100%;height:6px;border-radius:3px;-webkit-appearance:none;appearance:none;background:var(--bg4);cursor:pointer;outline:none;}
+.slider-track::-webkit-slider-thumb{-webkit-appearance:none;width:22px;height:22px;border-radius:50%;background:var(--red);border:3px solid var(--bg3);box-shadow:0 0 0 2px var(--red),0 4px 12px rgba(192,57,43,0.4);cursor:pointer;transition:transform .15s;}
+.slider-track::-webkit-slider-thumb:hover{transform:scale(1.15);}
+.slider-track::-moz-range-thumb{width:22px;height:22px;border-radius:50%;background:var(--red);border:3px solid var(--bg3);cursor:pointer;}
+.slider-labels{display:flex;justify-content:space-between;margin-top:.6rem;}
+.slider-label{font-size:.65rem;font-weight:700;color:var(--text4);font-family:'Barlow Condensed',sans-serif;letter-spacing:.04em;}
+.plan-hint{display:flex;align-items:flex-start;gap:.65rem;padding:.9rem 1rem;background:var(--bg4);border:1px solid var(--border2);border-radius:8px;margin-top:1rem;transition:all .3s;}
+.plan-hint-icon{font-size:1.2rem;flex-shrink:0;margin-top:1px;}
+.plan-hint-name{font-weight:900;font-size:.9rem;color:var(--text);}
+.plan-hint-desc{font-size:.78rem;color:var(--text2);margin-top:.15rem;line-height:1.5;}
+.plan-hint-price{font-family:'Barlow Condensed',sans-serif;font-size:1.1rem;font-weight:900;color:var(--red);margin-left:auto;flex-shrink:0;padding-left:.75rem;align-self:center;}
+.btn-submit{width:100%;padding:1rem;border-radius:8px;background:var(--red);color:#fff;font-size:.95rem;font-weight:900;font-family:'Barlow Condensed',sans-serif;letter-spacing:.07em;text-transform:uppercase;border:none;cursor:pointer;display:flex;align-items:center;justify-content:center;gap:.6rem;transition:all .25s;margin-top:1.5rem;box-shadow:0 4px 16px rgba(192,57,43,0.3);position:relative;overflow:hidden;}
+.btn-submit::before{content:'';position:absolute;inset:0;background:linear-gradient(90deg,transparent,rgba(255,255,255,0.08),transparent);transform:translateX(-100%);transition:transform .4s;}
+.btn-submit:hover{background:var(--red-light);transform:translateY(-2px);box-shadow:0 8px 28px rgba(192,57,43,0.45);}
+.btn-submit:hover::before{transform:translateX(100%);}
+.btn-submit:disabled{opacity:.5;cursor:not-allowed;transform:none;}
+.btn-submit .arrow{transition:transform .2s;}
+.btn-submit:hover .arrow{transform:translateX(4px);}
+.submit-note{display:flex;align-items:center;justify-content:center;gap:.4rem;font-size:.72rem;color:var(--text3);margin-top:.75rem;}
+.form-success{display:none;text-align:center;padding:3rem 2rem;}
+.form-success.visible{display:block;}
+.success-icon{width:64px;height:64px;border-radius:50%;background:rgba(16,185,129,0.12);border:2px solid var(--green);display:flex;align-items:center;justify-content:center;font-size:1.8rem;margin:0 auto 1.5rem;animation:popIn .5s cubic-bezier(0.175,0.885,0.32,1.275);}
+@keyframes popIn{from{transform:scale(0);opacity:0;}to{transform:scale(1);opacity:1;}}
+.success-title{font-family:'Barlow Condensed',sans-serif;font-size:2rem;font-weight:900;color:var(--green);margin-bottom:.5rem;}
+.success-body{font-size:.9rem;color:var(--text2);line-height:1.7;max-width:340px;margin:0 auto;}
 
-/* FORM FIELDS */
-.form-row{display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-bottom:1rem}
-.form-row.solo{grid-template-columns:1fr}
-.form-field{display:flex;flex-direction:column;gap:0.4rem}
-.form-label{
-  font-size:0.68rem;font-weight:800;
-  color:var(--text3);
-  text-transform:uppercase;letter-spacing:0.08em;
-  font-family:'Barlow Condensed',sans-serif;
-}
-.form-input{
-  background:var(--bg3);
-  border:1.5px solid var(--border2);
-  border-radius:var(--r);
-  padding:0.7rem 0.95rem;
-  font-size:0.88rem;color:var(--text);
-  outline:none;
-  font-family:'Barlow',sans-serif;
-  transition:border 0.2s,box-shadow 0.2s;
-  width:100%;
-}
-.form-input::placeholder{color:var(--text4)}
-.form-input:focus{
-  border-color:var(--red);
-  box-shadow:0 0 0 3px rgba(239,68,68,0.1);
-  background:var(--bg4);
-}
-select.form-input{
-  -webkit-appearance:none;appearance:none;
-  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' fill='none'%3E%3Cpath stroke='%2366666e' stroke-width='1.5' d='M1 1l4 4 4-4'/%3E%3C/svg%3E");
-  background-repeat:no-repeat;background-position:right 1rem center;
-  cursor:pointer;
-}
-select.form-input option{background:var(--bg3);color:var(--text)}
-textarea.form-input{resize:vertical;min-height:80px;line-height:1.6}
+/* ── LEFT PANEL ── */
+.trust-bar{display:grid;grid-template-columns:repeat(3,1fr);background:var(--bg3);border:1px solid var(--border);border-radius:var(--radius);overflow:hidden;margin-bottom:2.5rem;}
+.trust-item{padding:1.25rem 1rem;text-align:center;border-right:1px solid var(--border);transition:background .2s;}
+.trust-item:last-child{border-right:none;}
+.trust-item:hover{background:var(--bg4);}
+.trust-num{font-family:'Bebas Neue',sans-serif;font-size:2.2rem;line-height:1;color:var(--red);}
+.trust-label{font-size:.65rem;font-weight:700;color:var(--text3);text-transform:uppercase;letter-spacing:.06em;margin-top:.3rem;}
+.panel-section{margin-bottom:2.5rem;}
+.panel-label{font-family:'Barlow Condensed',sans-serif;font-size:.7rem;font-weight:900;color:var(--text3);text-transform:uppercase;letter-spacing:.1em;display:flex;align-items:center;gap:.5rem;margin-bottom:1.25rem;}
+.panel-label::after{content:'';flex:1;height:1px;background:var(--border);}
+.timeline{display:flex;flex-direction:column;gap:0;}
+.timeline-item{display:grid;grid-template-columns:28px 1fr;gap:.85rem;position:relative;padding-bottom:1.5rem;}
+.timeline-item:last-child{padding-bottom:0;}
+.tl-dot{width:28px;height:28px;border-radius:50%;background:var(--bg3);border:2px solid var(--border2);display:flex;align-items:center;justify-content:center;font-size:.7rem;font-weight:900;color:var(--text3);flex-shrink:0;position:relative;z-index:1;font-family:'Barlow Condensed',sans-serif;transition:all .3s;}
+.timeline-item:hover .tl-dot{border-color:var(--red);color:var(--red);}
+.timeline-item:not(:last-child) .tl-dot::after{content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);width:1px;height:calc(100% + 1.25rem + 4px);background:linear-gradient(to bottom,var(--border2),transparent);}
+.tl-content{padding-top:3px;}
+.tl-title{font-weight:800;font-size:.9rem;color:var(--text);margin-bottom:.2rem;}
+.tl-desc{font-size:.78rem;color:var(--text2);line-height:1.5;}
+.includes-grid{display:grid;grid-template-columns:1fr 1fr;gap:.6rem;}
+.include-item{display:flex;align-items:flex-start;gap:.6rem;padding:.75rem;background:var(--bg3);border:1px solid var(--border);border-radius:8px;transition:all .2s;}
+.include-item:hover{border-color:rgba(192,57,43,0.3);background:var(--red-dim);}
+.include-icon{font-size:1rem;flex-shrink:0;margin-top:1px;}
+.include-text{font-size:.78rem;font-weight:700;color:var(--text2);line-height:1.4;}
+.testimonial-card{background:var(--bg3);border:1px solid var(--border2);border-radius:var(--radius);padding:1.5rem;position:relative;overflow:hidden;}
+.testimonial-card::before{content:'"';position:absolute;top:-.5rem;left:1rem;font-family:'Bebas Neue',sans-serif;font-size:6rem;line-height:1;color:rgba(192,57,43,0.07);pointer-events:none;}
+.testimonial-stars{color:var(--gold2);font-size:.9rem;margin-bottom:.75rem;letter-spacing:2px;}
+.testimonial-text{font-size:.88rem;color:var(--text2);line-height:1.7;font-style:italic;margin-bottom:1rem;}
+.testimonial-author{display:flex;align-items:center;gap:.75rem;}
+.testimonial-avatar{width:36px;height:36px;border-radius:50%;background:linear-gradient(135deg,var(--red),var(--gold));display:flex;align-items:center;justify-content:center;font-size:.8rem;font-weight:900;color:#fff;font-family:'Barlow Condensed',sans-serif;flex-shrink:0;}
+.testimonial-name{font-size:.82rem;font-weight:800;color:var(--text);}
+.testimonial-role{font-size:.72rem;color:var(--text3);}
+.faq-list{display:flex;flex-direction:column;gap:.5rem;}
+.faq-item{background:var(--bg3);border:1px solid var(--border);border-radius:8px;overflow:hidden;}
+.faq-q{width:100%;padding:.9rem 1rem;display:flex;justify-content:space-between;align-items:center;background:none;border:none;cursor:pointer;font-size:.82rem;font-weight:700;color:var(--text2);font-family:'Barlow',sans-serif;text-align:left;transition:color .2s;}
+.faq-q:hover{color:var(--text);}
+.faq-chevron{font-size:.7rem;color:var(--text3);transition:transform .25s;flex-shrink:0;}
+.faq-item.open .faq-chevron{transform:rotate(180deg);}
+.faq-a{max-height:0;overflow:hidden;transition:max-height .3s ease,padding .3s;font-size:.8rem;color:var(--text2);line-height:1.65;padding:0 1rem;}
+.faq-item.open .faq-a{max-height:200px;padding:0 1rem 1rem;}
 
-/* DIVIDER */
-.form-divider{
-  display:flex;align-items:center;gap:0.75rem;
-  margin:1.5rem 0 1.25rem;
-}
-.form-divider span{
-  font-size:0.68rem;font-weight:800;
-  color:var(--text3);text-transform:uppercase;
-  letter-spacing:0.08em;font-family:'Barlow Condensed',sans-serif;
-  white-space:nowrap;
-}
-.form-divider::before,.form-divider::after{
-  content:'';flex:1;height:1px;background:var(--border2);
-}
+/* ── FOOTER ── */
+footer{background:var(--surface);border-top:1px solid var(--border);padding:60px 5% 30px;}
+.footer-inner{max-width:1280px;margin:0 auto;}
+.footer-top{display:grid;grid-template-columns:1.5fr 1fr 1fr;gap:2.5rem;margin-bottom:3rem;}
+.footer-brand-logo{display:flex;align-items:center;gap:.6rem;margin-bottom:.75rem;}
+.footer-brand-logo img{height:36px;width:auto;}
+.footer-brand-logo-text{font-family:'Barlow Condensed',sans-serif;font-weight:900;font-size:1.1rem;letter-spacing:.05em;}
+.footer-brand p{font-size:.85rem;color:var(--muted);line-height:1.6;max-width:240px;}
+.footer-col h4{font-size:.75rem;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:var(--muted);margin-bottom:1rem;}
+.footer-col ul{list-style:none;display:flex;flex-direction:column;gap:.6rem;}
+.footer-col a{font-size:.88rem;color:var(--muted);transition:color .2s;}
+.footer-col a:hover{color:var(--text);}
+.footer-col span{font-size:.88rem;color:var(--muted);}
+.footer-bottom{border-top:1px solid var(--border);padding-top:1.5rem;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem;}
+.footer-bottom p{font-size:.8rem;color:var(--muted);}
+.footer-social{display:flex;gap:.6rem;}
+.fsoc{width:34px;height:34px;border-radius:6px;background:var(--surface2);border:1px solid var(--border);color:var(--muted);display:flex;align-items:center;justify-content:center;text-decoration:none;transition:all .2s;}
+.fsoc:hover{border-color:var(--red);}
 
-/* BUDGET SLIDER */
-.budget-section{margin-bottom:1.25rem}
-.budget-display{
-  display:flex;align-items:baseline;gap:0.5rem;margin-bottom:1rem;
-}
-.budget-amount{
-  font-family:'Bebas Neue',sans-serif;
-  font-size:3.5rem;line-height:1;
-  color:var(--text);
-  transition:color 0.3s;
-}
-.budget-period{font-size:0.8rem;color:var(--text3);font-weight:700;padding-bottom:0.3rem}
+/* ── REVEAL ── */
+.reveal{opacity:0;transform:translateY(20px);transition:opacity .6s ease,transform .6s ease;}
+.reveal.visible{opacity:1;transform:translateY(0);}
 
-/* Payment toggle */
-.payment-toggle{
-  display:inline-flex;
-  background:var(--bg3);
-  border:1px solid var(--border2);
-  border-radius:6px;
-  padding:3px;
-  margin-bottom:1.25rem;
-  gap:2px;
-}
-.toggle-btn{
-  padding:0.4rem 1rem;
-  border-radius:4px;
-  font-size:0.75rem;font-weight:800;
-  font-family:'Barlow Condensed',sans-serif;
-  letter-spacing:0.06em;text-transform:uppercase;
-  cursor:pointer;border:none;
-  background:transparent;color:var(--text3);
-  transition:all 0.2s;
-}
-.toggle-btn.active{
-  background:var(--red);color:#fff;
-  box-shadow:0 2px 8px rgba(239,68,68,0.3);
-}
-
-/* Slider */
-.slider-wrap{position:relative;padding-bottom:1.75rem}
-.slider-track{
-  width:100%;height:6px;
-  border-radius:3px;
-  -webkit-appearance:none;appearance:none;
-  background:var(--bg4);
-  cursor:pointer;outline:none;
-}
-.slider-track::-webkit-slider-thumb{
-  -webkit-appearance:none;
-  width:22px;height:22px;border-radius:50%;
-  background:var(--red);
-  border:3px solid var(--bg2);
-  box-shadow:0 0 0 2px var(--red),0 4px 12px rgba(239,68,68,0.4);
-  cursor:pointer;
-  transition:transform 0.15s,box-shadow 0.15s;
-}
-.slider-track::-webkit-slider-thumb:hover{
-  transform:scale(1.15);
-  box-shadow:0 0 0 3px var(--red),0 4px 16px rgba(239,68,68,0.5);
-}
-.slider-track::-moz-range-thumb{
-  width:22px;height:22px;border-radius:50%;
-  background:var(--red);
-  border:3px solid var(--bg2);
-  box-shadow:0 0 0 2px var(--red);
-  cursor:pointer;
-}
-.slider-labels{
-  display:flex;justify-content:space-between;
-  margin-top:0.6rem;
-}
-.slider-label{font-size:0.65rem;font-weight:700;color:var(--text4);font-family:'Barlow Condensed',sans-serif;letter-spacing:0.04em}
-
-/* Plan hint */
-.plan-hint{
-  display:flex;align-items:flex-start;gap:0.65rem;
-  padding:0.9rem 1rem;
-  background:var(--bg3);
-  border:1px solid var(--border2);
-  border-radius:var(--r);
-  margin-top:1rem;
-  transition:all 0.3s;
-}
-.plan-hint-icon{font-size:1.2rem;flex-shrink:0;margin-top:1px}
-.plan-hint-name{font-weight:900;font-size:0.9rem;color:var(--text);font-family:'Barlow',sans-serif}
-.plan-hint-desc{font-size:0.78rem;color:var(--text2);margin-top:0.15rem;line-height:1.5}
-.plan-hint-price{font-family:'Barlow Condensed',sans-serif;font-size:1.1rem;font-weight:900;color:var(--red);margin-left:auto;flex-shrink:0;padding-left:0.75rem;align-self:center}
-
-/* SUBMIT */
-.btn-submit{
-  width:100%;padding:1rem;
-  border-radius:var(--r);
-  background:var(--red);color:#fff;
-  font-size:0.95rem;font-weight:900;
-  font-family:'Barlow Condensed',sans-serif;
-  letter-spacing:0.07em;text-transform:uppercase;
-  border:none;cursor:pointer;
-  display:flex;align-items:center;justify-content:center;gap:0.6rem;
-  transition:all 0.25s;
-  margin-top:1.5rem;
-  box-shadow:0 4px 16px rgba(239,68,68,0.3);
-  position:relative;overflow:hidden;
-}
-.btn-submit::before{
-  content:'';position:absolute;inset:0;
-  background:linear-gradient(90deg,transparent,rgba(255,255,255,0.08),transparent);
-  transform:translateX(-100%);
-  transition:transform 0.4s;
-}
-.btn-submit:hover{background:var(--red2);transform:translateY(-2px);box-shadow:0 8px 28px rgba(239,68,68,0.45)}
-.btn-submit:hover::before{transform:translateX(100%)}
-.btn-submit:disabled{opacity:0.5;cursor:not-allowed;transform:none}
-.btn-submit:active{transform:translateY(0)}
-.btn-submit .arrow{transition:transform 0.2s}
-.btn-submit:hover .arrow{transform:translateX(4px)}
-.submit-note{display:flex;align-items:center;justify-content:center;gap:0.4rem;font-size:0.72rem;color:var(--text3);margin-top:0.75rem}
-
-/* SUCCESS STATE */
-.form-success{
-  display:none;text-align:center;padding:3rem 2rem;
-}
-.form-success.visible{display:block}
-.success-icon{
-  width:64px;height:64px;border-radius:50%;
-  background:rgba(16,185,129,0.12);border:2px solid var(--green);
-  display:flex;align-items:center;justify-content:center;
-  font-size:1.8rem;margin:0 auto 1.5rem;
-  animation:popIn 0.5s cubic-bezier(0.175,0.885,0.32,1.275);
-}
-@keyframes popIn{from{transform:scale(0);opacity:0}to{transform:scale(1);opacity:1}}
-.success-title{font-family:'Barlow Condensed',sans-serif;font-size:2rem;font-weight:900;color:var(--green);margin-bottom:0.5rem}
-.success-body{font-size:0.9rem;color:var(--text2);line-height:1.7;max-width:340px;margin:0 auto}
-
-/* LEFT PANEL */
-/* Trust bar */
-.trust-bar{
-  display:grid;grid-template-columns:repeat(3,1fr);gap:0;
-  background:var(--bg2);border:1px solid var(--border);
-  border-radius:var(--r2);overflow:hidden;margin-bottom:2.5rem;
-}
-.trust-item{
-  padding:1.25rem 1rem;text-align:center;
-  border-right:1px solid var(--border);
-  transition:background 0.2s;
-}
-.trust-item:last-child{border-right:none}
-.trust-item:hover{background:var(--bg3)}
-.trust-num{
-  font-family:'Bebas Neue',sans-serif;
-  font-size:2.2rem;line-height:1;color:var(--red);
-}
-.trust-label{font-size:0.65rem;font-weight:700;color:var(--text3);text-transform:uppercase;letter-spacing:0.06em;margin-top:0.3rem}
-
-/* What to expect */
-.panel-section{margin-bottom:2.5rem}
-.panel-label{
-  font-family:'Barlow Condensed',sans-serif;
-  font-size:0.7rem;font-weight:900;
-  color:var(--text3);text-transform:uppercase;letter-spacing:0.1em;
-  display:flex;align-items:center;gap:0.5rem;margin-bottom:1.25rem;
-}
-.panel-label::after{content:'';flex:1;height:1px;background:var(--border)}
-
-/* Timeline */
-.timeline{display:flex;flex-direction:column;gap:0}
-.timeline-item{
-  display:grid;grid-template-columns:28px 1fr;gap:0.85rem;
-  position:relative;padding-bottom:1.5rem;
-}
-.timeline-item:last-child{padding-bottom:0}
-.tl-dot{
-  width:28px;height:28px;border-radius:50%;
-  background:var(--bg3);border:2px solid var(--border2);
-  display:flex;align-items:center;justify-content:center;
-  font-size:0.7rem;font-weight:900;color:var(--text3);
-  flex-shrink:0;position:relative;z-index:1;
-  font-family:'Barlow Condensed',sans-serif;
-  transition:all 0.3s;
-}
-.timeline-item:hover .tl-dot{border-color:var(--red);color:var(--red)}
-.timeline-item:not(:last-child) .tl-dot::after{
-  content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);
-  width:1px;height:calc(100% + 1.25rem + 4px);
-  background:linear-gradient(to bottom,var(--border2),transparent);
-}
-.tl-content{padding-top:3px}
-.tl-title{font-weight:800;font-size:0.9rem;color:var(--text);margin-bottom:0.2rem}
-.tl-desc{font-size:0.78rem;color:var(--text2);line-height:1.5}
-
-/* What's included */
-.includes-grid{display:grid;grid-template-columns:1fr 1fr;gap:0.6rem}
-.include-item{
-  display:flex;align-items:flex-start;gap:0.6rem;
-  padding:0.75rem;
-  background:var(--bg2);border:1px solid var(--border);
-  border-radius:var(--r);transition:all 0.2s;
-}
-.include-item:hover{border-color:rgba(239,68,68,0.3);background:var(--red-dim)}
-.include-icon{font-size:1rem;flex-shrink:0;margin-top:1px}
-.include-text{font-size:0.78rem;font-weight:700;color:var(--text2);line-height:1.4}
-
-/* Testimonial */
-.testimonial-card{
-  background:var(--bg2);
-  border:1px solid var(--border2);
-  border-radius:var(--r2);
-  padding:1.5rem;
-  position:relative;
-  overflow:hidden;
-}
-.testimonial-card::before{
-  content:'"';
-  position:absolute;top:-0.5rem;left:1rem;
-  font-family:'Bebas Neue',sans-serif;
-  font-size:6rem;line-height:1;
-  color:rgba(239,68,68,0.07);
-  pointer-events:none;
-}
-.testimonial-stars{color:var(--gold2);font-size:0.9rem;margin-bottom:0.75rem;letter-spacing:2px}
-.testimonial-text{font-size:0.88rem;color:var(--text2);line-height:1.7;font-style:italic;margin-bottom:1rem}
-.testimonial-author{display:flex;align-items:center;gap:0.75rem}
-.testimonial-avatar{
-  width:36px;height:36px;border-radius:50%;
-  background:linear-gradient(135deg,var(--red),var(--gold));
-  display:flex;align-items:center;justify-content:center;
-  font-size:0.8rem;font-weight:900;color:#fff;
-  font-family:'Barlow Condensed',sans-serif;
-  flex-shrink:0;
-}
-.testimonial-name{font-size:0.82rem;font-weight:800;color:var(--text)}
-.testimonial-role{font-size:0.72rem;color:var(--text3)}
-
-/* FAQ compact */
-.faq-list{display:flex;flex-direction:column;gap:0.5rem}
-.faq-item{
-  background:var(--bg2);border:1px solid var(--border);
-  border-radius:var(--r);overflow:hidden;
-}
-.faq-q{
-  width:100%;padding:0.9rem 1rem;
-  display:flex;justify-content:space-between;align-items:center;
-  background:none;border:none;cursor:pointer;
-  font-size:0.82rem;font-weight:700;color:var(--text2);
-  font-family:'Barlow',sans-serif;text-align:left;
-  transition:color 0.2s;
-}
-.faq-q:hover{color:var(--text)}
-.faq-chevron{font-size:0.7rem;color:var(--text3);transition:transform 0.25s;flex-shrink:0}
-.faq-item.open .faq-chevron{transform:rotate(180deg)}
-.faq-a{
-  max-height:0;overflow:hidden;
-  transition:max-height 0.3s ease,padding 0.3s;
-  font-size:0.8rem;color:var(--text2);line-height:1.65;
-  padding:0 1rem;
-}
-.faq-item.open .faq-a{max-height:200px;padding:0 1rem 1rem}
-
-/* FOOTER */
-footer{
-  background:var(--bg2);
-  border-top:1px solid var(--border);
-  padding:1.75rem 2rem;
-}
-.footer-inner{max-width:1100px;margin:0 auto;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem}
-.footer-copy{font-size:0.75rem;color:var(--text3)}
-.footer-links{display:flex;gap:1.5rem}
-.footer-links a{font-size:0.75rem;color:var(--text3);text-decoration:none;transition:color 0.2s}
-.footer-links a:hover{color:var(--red)}
-.footer-social{display:flex;gap:0.5rem}
-.fsoc{width:32px;height:32px;border-radius:6px;background:var(--bg3);border:1px solid var(--border2);color:var(--text3);display:flex;align-items:center;justify-content:center;text-decoration:none;font-size:0.85rem;transition:all 0.2s}
-.fsoc:hover{border-color:var(--red);color:var(--red)}
-
-/* ANIMATIONS */
-.reveal{opacity:0;transform:translateY(20px);transition:opacity 0.6s ease,transform 0.6s ease}
-.reveal.visible{opacity:1;transform:translateY(0)}
-
-/* RESPONSIVE */
+/* ── RESPONSIVE ── */
 @media(max-width:900px){
-  .main-wrap{grid-template-columns:1fr;gap:2rem}
-  .form-card{position:static}
-  .left-panel{order:1}
-  .form-card{order:-1}
+  .main-wrap{grid-template-columns:1fr;gap:2rem;}
+  .form-card{position:static;}
+  .left-panel{order:1;}
+  .form-card{order:-1;}
+  .footer-top{grid-template-columns:1fr 1fr;}
 }
 @media(max-width:640px){
-  nav{padding:0 1rem;height:60px}
-  .nav-links,.nav-right{display:none}
-  .hamburger{display:flex}
-  .mobile-menu{top:60px}
-  .hero{padding:4rem 1.5rem 2.5rem}
-  .hero h1{font-size:clamp(3rem,12vw,5rem)}
-  .main-wrap{padding:2rem 1rem 4rem}
-  .form-row{grid-template-columns:1fr}
-  .form-body{padding:1.5rem 1.25rem}
-  .form-card-header{padding:1.5rem 1.25rem 1.25rem}
-  .includes-grid{grid-template-columns:1fr}
-  .trust-bar{grid-template-columns:repeat(3,1fr)}
-  .trust-num{font-size:1.6rem}
+  nav{padding:0 4%;height:60px;}
+  .nav-links,.nav-right{display:none;}
+  .hamburger{display:flex;}
+  .mobile-menu{top:60px;}
+  .hero{padding:4rem 1.5rem 2.5rem;}
+  .hero h1{font-size:clamp(3rem,12vw,5rem);}
+  .main-wrap{padding:2rem 1rem 4rem;}
+  .form-row{grid-template-columns:1fr;}
+  .form-body{padding:1.5rem 1.25rem;}
+  .form-card-header{padding:1.5rem 1.25rem 1.25rem;}
+  .includes-grid{grid-template-columns:1fr;}
+  .footer-top{grid-template-columns:1fr;}
+  .footer-bottom{flex-direction:column;text-align:center;}
 }
 </style>
 </head>
@@ -537,6 +226,7 @@ footer{
     <ul class="nav-links">
       <li><a href="index.html">Home</a></li>
       <li><a href="about.html">About</a></li>
+      <li><a href="arsenal.html">Arsenal 001</a></li>
     </ul>
     <div class="nav-right">
       <a href="apply.html" class="nav-cta">Apply Now</a>
@@ -547,6 +237,7 @@ footer{
 <div class="mobile-menu" id="mobileMenu">
   <a href="index.html" onclick="closeMenu()">Home</a>
   <a href="about.html" onclick="closeMenu()">About</a>
+  <a href="arsenal.html" onclick="closeMenu()">Arsenal 001</a>
   <a href="apply.html" onclick="closeMenu()">Apply Now</a>
 </div>
 
@@ -554,11 +245,11 @@ footer{
 <section class="hero">
   <div class="hero-ticker">
     <span class="ticker-dot"></span>
-    Now Accepting Applications   Limited Spots Per Month
+    Now Accepting Applications — Limited Spots Per Month
   </div>
   <h1>Get Your<br><span class="line2">Site. Win Jobs.</span></h1>
   <p class="hero-sub">
-    Tell us about your business. We'll build you a <strong>lead machine</strong> that works 24/7   launched in <strong>48-72 hours</strong>.
+    Tell us about your business. We'll build you a <strong>lead machine</strong> that works 24/7 — launched in <strong>48-72 hours</strong>.
   </p>
   <div class="hero-chips">
     <div class="hero-chip"><span class="dot"></span> 60-Second Form</div>
@@ -573,7 +264,6 @@ footer{
   <!-- LEFT: SOCIAL PROOF + INFO -->
   <div class="left-panel">
 
-    <!-- Trust bar -->
     <div class="trust-bar reveal">
       <div class="trust-item">
         <div class="trust-num">50+</div>
@@ -589,15 +279,14 @@ footer{
       </div>
     </div>
 
-    <!-- What to expect -->
-    <div class="panel-section reveal" style="transition-delay:0.1s">
+    <div class="panel-section reveal" style="transition-delay:.1s">
       <div class="panel-label">What Happens Next</div>
       <div class="timeline">
         <div class="timeline-item">
           <div class="tl-dot">1</div>
           <div class="tl-content">
             <div class="tl-title">You Submit</div>
-            <div class="tl-desc">Takes 60 seconds. We review every application personally   no bots.</div>
+            <div class="tl-desc">Takes 60 seconds. We review every application personally — no bots.</div>
           </div>
         </div>
         <div class="timeline-item">
@@ -624,89 +313,56 @@ footer{
       </div>
     </div>
 
-    <!-- What's included -->
-    <div class="panel-section reveal" style="transition-delay:0.15s">
+    <div class="panel-section reveal" style="transition-delay:.15s">
       <div class="panel-label">Every Site Includes</div>
       <div class="includes-grid">
-        <div class="include-item">
-          <div class="include-icon">🎨</div>
-          <div class="include-text">Custom Design &amp; Copywriting</div>
-        </div>
-        <div class="include-item">
-          <div class="include-icon">🔍</div>
-          <div class="include-text">Full Local SEO Setup</div>
-        </div>
-        <div class="include-item">
-          <div class="include-icon">📱</div>
-          <div class="include-text">Mobile-First Responsive</div>
-        </div>
-        <div class="include-item">
-          <div class="include-icon">📞</div>
-          <div class="include-text">Lead Forms + Click-to-Call</div>
-        </div>
-        <div class="include-item">
-          <div class="include-icon">📍</div>
-          <div class="include-text">Google Business Integration</div>
-        </div>
-        <div class="include-item">
-          <div class="include-icon">⚡</div>
-          <div class="include-text">30 Days Free Edits</div>
-        </div>
+        <div class="include-item"><div class="include-icon">🎨</div><div class="include-text">Custom Design &amp; Copywriting</div></div>
+        <div class="include-item"><div class="include-icon">🔍</div><div class="include-text">Full Local SEO Setup</div></div>
+        <div class="include-item"><div class="include-icon">📱</div><div class="include-text">Mobile-First Responsive</div></div>
+        <div class="include-item"><div class="include-icon">📞</div><div class="include-text">Lead Forms + Click-to-Call</div></div>
+        <div class="include-item"><div class="include-icon">📍</div><div class="include-text">Google Business Integration</div></div>
+        <div class="include-item"><div class="include-icon">⚡</div><div class="include-text">30 Days Free Edits</div></div>
       </div>
     </div>
 
-    <!-- Testimonial -->
-    <div class="panel-section reveal" style="transition-delay:0.2s">
+    <div class="panel-section reveal" style="transition-delay:.2s">
       <div class="panel-label">From a Contractor</div>
       <div class="testimonial-card">
         <div class="testimonial-stars">★★★★★</div>
-        <p class="testimonial-text">"I was skeptical   had a bad experience with web guys before. These guys launched my site in two days and I got my first lead the same week. Phone doesn't stop now."</p>
+        <p class="testimonial-text">"I was skeptical — had a bad experience with web guys before. These guys launched my site in two days and I got my first lead the same week. Phone doesn't stop now."</p>
         <div class="testimonial-author">
           <div class="testimonial-avatar">MR</div>
           <div>
             <div class="testimonial-name">Mike R.</div>
-            <div class="testimonial-role">Roofing Contractor   Charlotte, NC</div>
+            <div class="testimonial-role">Roofing Contractor — Charlotte, NC</div>
           </div>
         </div>
       </div>
     </div>
 
-    <!-- FAQ -->
-    <div class="panel-section reveal" style="transition-delay:0.25s">
+    <div class="panel-section reveal" style="transition-delay:.25s">
       <div class="panel-label">Quick FAQ</div>
       <div class="faq-list">
         <div class="faq-item">
-          <button class="faq-q" onclick="toggleFaq(this)">
-            Do I need to provide anything?
-            <span class="faq-chevron">&#9660;</span>
-          </button>
-          <div class="faq-a">Just your logo (if you have one), a couple photos, and 15 minutes on a call. We handle everything else   writing, design, and launch.</div>
+          <button class="faq-q" onclick="toggleFaq(this)">Do I need to provide anything? <span class="faq-chevron">&#9660;</span></button>
+          <div class="faq-a">Just your logo (if you have one), a couple photos, and 15 minutes on a call. We handle everything else — writing, design, and launch.</div>
         </div>
         <div class="faq-item">
-          <button class="faq-q" onclick="toggleFaq(this)">
-            What if I already have a website?
-            <span class="faq-chevron">&#9660;</span>
-          </button>
-          <div class="faq-a">We can rebuild it from scratch or start fresh. Most contractors who come to us have a site that doesn't generate leads   we fix that.</div>
+          <button class="faq-q" onclick="toggleFaq(this)">What if I already have a website? <span class="faq-chevron">&#9660;</span></button>
+          <div class="faq-a">We can rebuild it from scratch or start fresh. Most contractors who come to us have a site that doesn't generate leads — we fix that.</div>
         </div>
         <div class="faq-item">
-          <button class="faq-q" onclick="toggleFaq(this)">
-            Can I pay monthly instead of upfront?
-            <span class="faq-chevron">&#9660;</span>
-          </button>
-          <div class="faq-a">Yes   use the payment toggle on the form to see monthly options. We offer flexible plans so you can get started without a big upfront cost.</div>
+          <button class="faq-q" onclick="toggleFaq(this)">Can I pay monthly instead of upfront? <span class="faq-chevron">&#9660;</span></button>
+          <div class="faq-a">Yes — use the payment toggle on the form to see monthly options. We offer flexible plans so you can get started without a big upfront cost.</div>
         </div>
         <div class="faq-item">
-          <button class="faq-q" onclick="toggleFaq(this)">
-            Do I own the site?
-            <span class="faq-chevron">&#9660;</span>
-          </button>
-          <div class="faq-a">100%. You own everything   domain, hosting, code. We're not holding you hostage. It's your business, your asset.</div>
+          <button class="faq-q" onclick="toggleFaq(this)">Do I own the site? <span class="faq-chevron">&#9660;</span></button>
+          <div class="faq-a">100%. You own everything — domain, hosting, code. We're not holding you hostage. It's your business, your asset.</div>
         </div>
       </div>
     </div>
 
-  </div><!-- /left-panel -->
+  </div>
 
   <!-- RIGHT: FORM -->
   <div class="form-card reveal">
@@ -721,11 +377,9 @@ footer{
       <div class="form-card-title">Let's Get You Built</div>
       <div class="form-card-sub">Takes 60 seconds. We'll review and reach out within 24 hours.</div>
     </div>
-
     <div class="form-body">
       <div id="formBody">
         <form id="applyForm">
-
           <div class="form-row">
             <div class="form-field">
               <label class="form-label" for="name">Your Name *</label>
@@ -760,6 +414,8 @@ footer{
                 <option value="Electrical">Electrical</option>
                 <option value="Concrete">Concrete</option>
                 <option value="Fencing">Fencing</option>
+                <option value="Flooring">Flooring</option>
+                <option value="General Contracting">General Contracting</option>
                 <option value="Cleaning">Cleaning</option>
                 <option value="Other">Other</option>
               </select>
@@ -776,27 +432,19 @@ footer{
             </div>
           </div>
 
-          <!-- BUDGET SECTION -->
-          <div class="form-divider">
-            <span>Your Budget</span>
-          </div>
+          <div class="form-divider"><span>Your Budget</span></div>
 
           <div class="budget-section">
             <div class="payment-toggle">
               <button type="button" class="toggle-btn active" id="btnOneTime" onclick="setPaymentType('onetime')">One-Time</button>
               <button type="button" class="toggle-btn" id="btnMonthly" onclick="setPaymentType('monthly')">Monthly</button>
             </div>
-
             <div class="budget-display">
               <div class="budget-amount" id="budgetDisplay">$2,500</div>
               <div class="budget-period" id="budgetPeriod">one-time</div>
             </div>
-
             <div class="slider-wrap">
-              <input type="range" class="slider-track" id="budgetSlider"
-                min="0" max="4" step="1" value="1"
-                oninput="updateBudget()"
-                style="background:linear-gradient(to right,#EF4444 0%,#EF4444 25%,#26262c 25%,#26262c 100%)">
+              <input type="range" class="slider-track" id="budgetSlider" min="0" max="4" step="1" value="1" oninput="updateBudget()" style="background:linear-gradient(to right,#C0392B 0%,#C0392B 25%,#26262c 25%,#26262c 100%)">
               <div class="slider-labels">
                 <span class="slider-label" id="slabel0">$1,500</span>
                 <span class="slider-label" id="slabel1">$2,500</span>
@@ -805,7 +453,6 @@ footer{
                 <span class="slider-label" id="slabel4">Custom</span>
               </div>
             </div>
-
             <div class="plan-hint" id="planHint">
               <div class="plan-hint-icon" id="planIcon">🚀</div>
               <div>
@@ -814,7 +461,6 @@ footer{
               </div>
               <div class="plan-hint-price" id="planPrice">$2,500</div>
             </div>
-
             <input type="hidden" id="budgetInput" name="budget" value="$2,500 one-time">
             <input type="hidden" id="paymentTypeInput" name="payment_type" value="one-time">
           </div>
@@ -829,174 +475,143 @@ footer{
           </div>
         </form>
       </div>
-
-      <!-- Success state -->
       <div class="form-success" id="formSuccess">
         <div class="success-icon">&#10003;</div>
         <div class="success-title">You're In.</div>
-        <p class="success-body">Application received. We'll review it personally and reach out within 24 hours. Check your email and phone   this could be the best call you take all week.</p>
+        <p class="success-body">Application received. We'll review it personally and reach out within 24 hours. Check your email and phone — this could be the best call you take all week.</p>
       </div>
     </div>
-  </div><!-- /form-card -->
+  </div>
 
-</div><!-- /main-wrap -->
+</div>
 
 <!-- FOOTER -->
 <footer>
   <div class="footer-inner">
-    <span class="footer-copy">&copy; 2025 Contractor Arsenal. All rights reserved.</span>
-    <div class="footer-links">
-      <a href="index.html">Home</a>
-      <a href="about.html">About</a>
+    <div class="footer-top">
+      <div class="footer-brand">
+        <div class="footer-brand-logo">
+          <img src="https://storage.googleapis.com/msgsndr/kfZT6c91jZcZU6PUztl8/media/69387c0a578cc7a588bf9199.png" alt="Contractor Arsenal">
+          <span class="footer-brand-logo-text">Contractor Arsenal</span>
+        </div>
+        <p>Done-for-you websites built for contractors who want more local jobs and less tech headaches.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Navigate</h4>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="apply.html">Apply Now</a></li>
+          <li><a href="arsenal.html">Arsenal 001</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Services</h4>
+        <ul>
+          <li><span>Website Design</span></li>
+          <li><span>Local SEO</span></li>
+          <li><span>Copywriting</span></li>
+          <li><span>Mobile Optimization</span></li>
+          <li><span>Ongoing Support</span></li>
+        </ul>
+      </div>
     </div>
-    <div class="footer-social">
-      <a href="https://www.instagram.com/contractorarsenal/" target="_blank" rel="noopener" class="fsoc" title="Instagram">
-        <svg width="15" height="15" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/></svg>
-      </a>
+    <div class="footer-bottom">
+      <p>&copy; 2025 Contractor Arsenal. All rights reserved.</p>
+      <div class="footer-social">
+        <a href="https://www.instagram.com/contractorarsenal/" target="_blank" rel="noopener" class="fsoc" title="Instagram">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none"><defs><linearGradient id="ig" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#FFDC80"/><stop offset="30%" stop-color="#F77737"/><stop offset="60%" stop-color="#C13584"/><stop offset="100%" stop-color="#515BD4"/></linearGradient></defs><rect x="2" y="2" width="20" height="20" rx="5.5" fill="url(#ig)"/><circle cx="12" cy="12" r="4.2" stroke="#fff" stroke-width="1.8" fill="none"/><circle cx="17.2" cy="6.8" r="1.1" fill="#fff"/></svg>
+        </a>
+      </div>
     </div>
   </div>
 </footer>
 
 <script>
-// MOBILE MENU
-function toggleMenu(){
-  document.getElementById('hamburger').classList.toggle('open');
-  document.getElementById('mobileMenu').classList.toggle('open');
-}
-function closeMenu(){
-  document.getElementById('hamburger').classList.remove('open');
-  document.getElementById('mobileMenu').classList.remove('open');
-}
+function toggleMenu(){document.getElementById('hamburger').classList.toggle('open');document.getElementById('mobileMenu').classList.toggle('open');}
+function closeMenu(){document.getElementById('hamburger').classList.remove('open');document.getElementById('mobileMenu').classList.remove('open');}
 
-// BUDGET DATA
-var plans = {
-  onetime: [
-    { label:'$1,500', amount:'$1,500', name:'Starter Site', desc:'3 pages, mobile-responsive, basic SEO. Get online fast.', icon:'⚡', price:'$1,500' },
-    { label:'$2,500', amount:'$2,500', name:'Essential Site', desc:'5 custom pages, full SEO, lead forms, Google Business. Perfect for solo operators.', icon:'🚀', price:'$2,500' },
-    { label:'$3,500', amount:'$3,500', name:'Premium Site', desc:'10 pages, advanced SEO, 5 city pages, blog, review widget. Built to dominate.', icon:'💎', price:'$3,500' },
-    { label:'$5,000', amount:'$5,000', name:'Elite Package', desc:'Everything in Premium + PPC landing pages, analytics dashboard, priority support.', icon:'👑', price:'$5,000' },
-    { label:'Custom', amount:'Custom', name:'Custom Build', desc:"Have something bigger in mind? Let's talk. We'll scope it together.", icon:'🤝', price:"Let's Talk" }
+var plans={
+  onetime:[
+    {label:'$1,500',amount:'$1,500',name:'Starter Site',desc:'3 pages, mobile-responsive, basic SEO. Get online fast.',icon:'⚡',price:'$1,500'},
+    {label:'$2,500',amount:'$2,500',name:'Essential Site',desc:'5 custom pages, full SEO, lead forms, Google Business. Perfect for solo operators.',icon:'🚀',price:'$2,500'},
+    {label:'$3,500',amount:'$3,500',name:'Premium Site',desc:'10 pages, advanced SEO, 5 city pages, blog, review widget. Built to dominate.',icon:'💎',price:'$3,500'},
+    {label:'$5,000',amount:'$5,000',name:'Elite Package',desc:'Everything in Premium + PPC landing pages, analytics dashboard, priority support.',icon:'👑',price:'$5,000'},
+    {label:'Custom',amount:'Custom',name:'Custom Build',desc:"Have something bigger in mind? Let's talk. We'll scope it together.",icon:'🤝',price:"Let's Talk"}
   ],
-  monthly: [
-    { label:'$199/mo', amount:'$199/mo', name:'Starter Monthly', desc:'3-page site + hosting + support. Low barrier to get you online.', icon:'⚡', price:'$199/mo' },
-    { label:'$299/mo', amount:'$299/mo', name:'Growth Plan', desc:'5 pages, full SEO, lead forms. Everything you need to start generating calls.', icon:'🚀', price:'$299/mo' },
-    { label:'$449/mo', amount:'$449/mo', name:'Premium Plan', desc:'10 pages, city SEO expansion, blog, review widget. Serious growth mode.', icon:'💎', price:'$449/mo' },
-    { label:'$699/mo', amount:'$699/mo', name:'Elite Plan', desc:'Full-service: site, SEO, Google Ads management, reporting. All in.', icon:'👑', price:'$699/mo' },
-    { label:'Custom', amount:'Custom', name:'Custom Plan', desc:"Need something tailored? We do custom monthly retainers too.", icon:'🤝', price:"Let's Talk" }
+  monthly:[
+    {label:'$199/mo',amount:'$199/mo',name:'Starter Monthly',desc:'3-page site + hosting + support. Low barrier to get you online.',icon:'⚡',price:'$199/mo'},
+    {label:'$299/mo',amount:'$299/mo',name:'Growth Plan',desc:'5 pages, full SEO, lead forms. Everything you need to start generating calls.',icon:'🚀',price:'$299/mo'},
+    {label:'$449/mo',amount:'$449/mo',name:'Premium Plan',desc:'10 pages, city SEO expansion, blog, review widget. Serious growth mode.',icon:'💎',price:'$449/mo'},
+    {label:'$699/mo',amount:'$699/mo',name:'Elite Plan',desc:'Full-service: site, SEO, Google Ads management, reporting. All in.',icon:'👑',price:'$699/mo'},
+    {label:'Custom',amount:'Custom',name:'Custom Plan',desc:"Need something tailored? We do custom monthly retainers too.",icon:'🤝',price:"Let's Talk"}
   ]
 };
-
-var paymentType = 'onetime';
-
-function setPaymentType(type) {
-  paymentType = type;
-  document.getElementById('btnOneTime').classList.toggle('active', type === 'onetime');
-  document.getElementById('btnMonthly').classList.toggle('active', type === 'monthly');
-  var data = plans[type];
-  for (var i = 0; i < 5; i++) {
-    document.getElementById('slabel' + i).textContent = data[i].label;
-  }
+var paymentType='onetime';
+function setPaymentType(type){
+  paymentType=type;
+  document.getElementById('btnOneTime').classList.toggle('active',type==='onetime');
+  document.getElementById('btnMonthly').classList.toggle('active',type==='monthly');
+  var data=plans[type];
+  for(var i=0;i<5;i++) document.getElementById('slabel'+i).textContent=data[i].label;
   updateBudget();
 }
-
-function updateBudget() {
-  var val = parseInt(document.getElementById('budgetSlider').value);
-  var data = plans[paymentType][val];
-  var pct = (val / 4) * 100;
-
-  document.getElementById('budgetSlider').style.background =
-    'linear-gradient(to right, #EF4444 0%, #EF4444 ' + pct + '%, #26262c ' + pct + '%, #26262c 100%)';
-
-  document.getElementById('budgetDisplay').textContent = data.amount;
-  document.getElementById('budgetPeriod').textContent = paymentType === 'onetime' ? 'one-time' : 'per month';
-  document.getElementById('planIcon').textContent = data.icon;
-  document.getElementById('planName').textContent = data.name;
-  document.getElementById('planDesc').textContent = data.desc;
-  document.getElementById('planPrice').textContent = data.price;
-
-  document.getElementById('budgetInput').value = data.amount + ' ' + (paymentType === 'onetime' ? 'one-time' : 'monthly');
-  document.getElementById('paymentTypeInput').value = paymentType;
-
+function updateBudget(){
+  var val=parseInt(document.getElementById('budgetSlider').value);
+  var data=plans[paymentType][val];
+  var pct=(val/4)*100;
+  document.getElementById('budgetSlider').style.background='linear-gradient(to right,#C0392B 0%,#C0392B '+pct+'%,#26262c '+pct+'%,#26262c 100%)';
+  document.getElementById('budgetDisplay').textContent=data.amount;
+  document.getElementById('budgetPeriod').textContent=paymentType==='onetime'?'one-time':'per month';
+  document.getElementById('planIcon').textContent=data.icon;
+  document.getElementById('planName').textContent=data.name;
+  document.getElementById('planDesc').textContent=data.desc;
+  document.getElementById('planPrice').textContent=data.price;
+  document.getElementById('budgetInput').value=data.amount+' '+(paymentType==='onetime'?'one-time':'monthly');
+  document.getElementById('paymentTypeInput').value=paymentType;
   updateSteps();
 }
-
-// STEP INDICATOR
-function updateSteps() {
-  var fields = ['name','business','phone','email','trade','location'];
-  var filled = fields.filter(function(f) {
-    var el = document.getElementById(f);
-    return el && el.value.trim() !== '';
-  }).length;
-
-  var s1 = document.getElementById('step1dot');
-  var s2 = document.getElementById('step2dot');
-  var s3 = document.getElementById('step3dot');
-
-  if (filled >= 1) s1.classList.add('done'); else s1.classList.remove('done');
-  if (filled >= 4) s2.classList.add('done'); else s2.classList.remove('done');
-  if (filled >= 6) s3.classList.add('done'); else s3.classList.remove('done');
+function updateSteps(){
+  var fields=['name','business','phone','email','trade','location'];
+  var filled=fields.filter(function(f){var el=document.getElementById(f);return el&&el.value.trim()!=='';}).length;
+  var s1=document.getElementById('step1dot'),s2=document.getElementById('step2dot'),s3=document.getElementById('step3dot');
+  if(filled>=1)s1.classList.add('done');else s1.classList.remove('done');
+  if(filled>=4)s2.classList.add('done');else s2.classList.remove('done');
+  if(filled>=6)s3.classList.add('done');else s3.classList.remove('done');
 }
-
-document.querySelectorAll('.form-input').forEach(function(el) {
-  el.addEventListener('input', updateSteps);
-  el.addEventListener('change', updateSteps);
-});
-
-// FORM SUBMIT   Basin endpoint, stay on page
-document.getElementById('applyForm').addEventListener('submit', async function(e) {
+document.querySelectorAll('.form-input').forEach(function(el){el.addEventListener('input',updateSteps);el.addEventListener('change',updateSteps);});
+document.getElementById('applyForm').addEventListener('submit',async function(e){
   e.preventDefault();
-  var btn = document.getElementById('submitBtn');
-  btn.disabled = true;
-  btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" class="spin"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg> Sending...';
-
-  try {
-    var formData = new FormData(this);
-    var resp = await fetch('https://usebasin.com/f/2246e3a169bb', {
-      method: 'POST',
-      body: formData,
-      headers: { 'Accept': 'application/json' }
-    });
-
-    // Show success regardless of exact status   Basin returns 2xx on success
-    if (resp.ok || resp.status === 200 || resp.status === 201) {
-      document.getElementById('formBody').style.display = 'none';
+  var btn=document.getElementById('submitBtn');
+  btn.disabled=true;
+  btn.innerHTML='<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" class="spin"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg> Sending...';
+  try{
+    var formData=new FormData(this);
+    var resp=await fetch('https://usebasin.com/f/2246e3a169bb',{method:'POST',body:formData,headers:{'Accept':'application/json'}});
+    if(resp.ok||resp.status===200||resp.status===201){
+      document.getElementById('formBody').style.display='none';
       document.getElementById('formSuccess').classList.add('visible');
-      ['step1dot','step2dot','step3dot'].forEach(function(id) {
-        var el = document.getElementById(id);
-        el.classList.remove('active');
-        el.classList.add('done');
-        el.textContent = '✓';
-      });
-    } else {
-      throw new Error('Server error');
-    }
-  } catch(err) {
-    btn.disabled = false;
-    btn.innerHTML = 'Submit My Application <svg class="arrow" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>';
+      ['step1dot','step2dot','step3dot'].forEach(function(id){var el=document.getElementById(id);el.classList.remove('active');el.classList.add('done');el.textContent='✓';});
+    }else{throw new Error('Server error');}
+  }catch(err){
+    btn.disabled=false;
+    btn.innerHTML='Submit My Application <svg class="arrow" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path d="M5 12h14M12 5l7 7-7 7"/></svg>';
     alert('Something went wrong. Please try again or DM us on Instagram.');
   }
 });
-
-// SPINNER STYLE
-var style = document.createElement('style');
-style.textContent = '.spin{animation:spin 0.8s linear infinite}@keyframes spin{to{transform:rotate(360deg)}}';
+var style=document.createElement('style');
+style.textContent='.spin{animation:spin .8s linear infinite}@keyframes spin{to{transform:rotate(360deg)}}';
 document.head.appendChild(style);
-
-// FAQ TOGGLE
-function toggleFaq(btn) {
-  var item = btn.closest('.faq-item');
-  var wasOpen = item.classList.contains('open');
-  document.querySelectorAll('.faq-item').forEach(function(i) { i.classList.remove('open'); });
-  if (!wasOpen) item.classList.add('open');
+function toggleFaq(btn){
+  var item=btn.closest('.faq-item');
+  var wasOpen=item.classList.contains('open');
+  document.querySelectorAll('.faq-item').forEach(function(i){i.classList.remove('open');});
+  if(!wasOpen)item.classList.add('open');
 }
-
-// REVEAL ON SCROLL
-var observer = new IntersectionObserver(function(entries) {
-  entries.forEach(function(e) { if (e.isIntersecting) e.target.classList.add('visible'); });
-}, { threshold: 0.1 });
-document.querySelectorAll('.reveal').forEach(function(el) { observer.observe(el); });
-
-// INIT
+var observer=new IntersectionObserver(function(entries){
+  entries.forEach(function(e){if(e.isIntersecting)e.target.classList.add('visible');});
+},{threshold:0.1});
+document.querySelectorAll('.reveal').forEach(function(el){observer.observe(el);});
 updateBudget();
 </script>
 </body>

--- a/arsenal.html
+++ b/arsenal.html
@@ -1,0 +1,595 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Arsenal 001 | The Inner Circle for Elite Contractors</title>
+<meta name="description" content="Arsenal 001 is a private network for the top contractors in America. Where serious operators connect, grow, and win together.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700;800;900&family=Barlow+Condensed:wght@600;700;800;900&family=Bebas+Neue&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#0a0a0a;--surface:#111111;--surface2:#1a1a1a;
+  --border:rgba(255,255,255,0.08);--border2:rgba(255,255,255,0.14);
+  --red:#C0392B;--red-light:#E74C3C;
+  --gold:#F97316;--gold-light:#FB923C;
+  --text:#f0f0f0;--muted:#888;--radius:12px;
+}
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
+html{scroll-behavior:smooth;}
+body{background:var(--bg);color:var(--text);font-family:'Barlow',sans-serif;overflow-x:hidden;line-height:1.6;}
+a{color:inherit;text-decoration:none;}
+img{max-width:100%;height:auto;display:block;}
+::-webkit-scrollbar{width:3px;}
+::-webkit-scrollbar-track{background:var(--bg);}
+::-webkit-scrollbar-thumb{background:var(--red);border-radius:4px;}
+
+/* ── NAV ── */
+nav{position:fixed;top:0;left:0;right:0;z-index:1000;padding:0 5%;display:flex;align-items:center;justify-content:space-between;height:68px;background:rgba(10,10,10,0.95);backdrop-filter:blur(14px);border-bottom:1px solid var(--border);}
+.nav-logo{display:flex;align-items:center;gap:.6rem;}
+.nav-logo img{height:38px;width:auto;}
+.nav-logo-text{font-family:'Barlow Condensed',sans-serif;font-weight:900;font-size:1.1rem;letter-spacing:.05em;color:var(--text);}
+.nav-links{display:flex;gap:1.5rem;align-items:center;}
+.nav-links a{font-weight:600;font-size:.82rem;letter-spacing:.5px;text-transform:uppercase;color:var(--text);opacity:.75;transition:opacity .2s;}
+.nav-links a:hover{opacity:1;}
+.nav-links a.active{opacity:1;color:var(--gold);}
+.nav-cta{background:var(--red);color:#fff !important;padding:.5rem 1.25rem;border-radius:6px;font-weight:700;opacity:1 !important;transition:background .2s;}
+.nav-cta:hover{background:var(--red-light);}
+.nav-hamburger{display:none;flex-direction:column;gap:5px;cursor:pointer;padding:4px;background:none;border:none;}
+.nav-hamburger span{display:block;width:24px;height:2px;background:var(--text);border-radius:2px;transition:.3s;}
+.nav-mobile{display:none;position:fixed;top:68px;left:0;right:0;background:rgba(10,10,10,.98);padding:1.5rem 5%;flex-direction:column;gap:0;z-index:999;border-bottom:1px solid var(--border);}
+.nav-mobile.open{display:flex;}
+.nav-mobile a{font-weight:600;font-size:1rem;text-transform:uppercase;letter-spacing:.5px;padding:.9rem 0;border-bottom:1px solid var(--border);color:var(--text);}
+.nav-mobile a:hover{color:var(--gold);}
+
+/* ── HERO ── */
+.hero{min-height:100vh;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:120px 5% 80px;position:relative;overflow:hidden;text-align:center;}
+.hero-bg{position:absolute;inset:0;z-index:0;background:radial-gradient(ellipse 80% 60% at 50% 0%,rgba(192,57,43,0.18) 0%,transparent 65%);}
+.hero::before{content:'';position:absolute;bottom:0;left:0;right:0;height:1px;background:linear-gradient(90deg,transparent,rgba(192,57,43,0.5),transparent);}
+.noise-overlay{position:absolute;inset:0;z-index:1;opacity:.04;pointer-events:none;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");background-size:200px;}
+.hero-content{position:relative;z-index:2;max-width:820px;margin:0 auto;}
+.hero-badge{display:inline-flex;align-items:center;gap:.6rem;background:rgba(192,57,43,0.1);border:1px solid rgba(192,57,43,0.3);border-radius:100px;padding:.4rem 1rem;font-size:.75rem;font-weight:700;color:var(--red);letter-spacing:1.5px;text-transform:uppercase;margin-bottom:1.75rem;font-family:'Barlow Condensed',sans-serif;}
+.hero-badge::before{content:'';width:6px;height:6px;border-radius:50%;background:var(--red);animation:blink 1.5s infinite;}
+@keyframes blink{0%,100%{opacity:1;}50%{opacity:.3;}}
+.hero h1{font-family:'Bebas Neue',sans-serif;font-size:clamp(3.5rem,8vw,7rem);line-height:.95;letter-spacing:1px;margin-bottom:1.5rem;text-shadow:0 4px 30px rgba(0,0,0,0.5);}
+.hero h1 .line-gold{color:var(--gold);}
+.hero h1 .line-red{color:var(--red);}
+.hero-sub{font-size:1.15rem;color:rgba(240,240,240,0.75);max-width:580px;margin:0 auto 2.5rem;line-height:1.75;}
+.hero-ctas{display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;margin-bottom:3rem;}
+.btn-primary{background:var(--red);color:#fff;padding:.9rem 2.2rem;border-radius:8px;font-weight:700;font-size:1rem;letter-spacing:.5px;text-transform:uppercase;transition:all .2s;border:2px solid var(--red);display:inline-block;}
+.btn-primary:hover{background:var(--red-light);border-color:var(--red-light);transform:translateY(-2px);}
+.btn-ghost{border:1px solid rgba(255,255,255,0.2);color:rgba(240,240,240,0.8);padding:.9rem 2.2rem;border-radius:8px;font-weight:700;font-size:1rem;letter-spacing:.5px;text-transform:uppercase;transition:all .2s;display:inline-block;}
+.btn-ghost:hover{border-color:var(--gold);color:var(--gold);}
+
+/* Stats bar */
+.hero-stats{display:flex;gap:0;border:1px solid var(--border);border-radius:14px;overflow:hidden;background:rgba(17,17,17,0.8);backdrop-filter:blur(10px);max-width:640px;margin:0 auto;}
+.hero-stat{flex:1;padding:1.5rem 1rem;text-align:center;border-right:1px solid var(--border);transition:background .2s;}
+.hero-stat:last-child{border-right:none;}
+.hero-stat:hover{background:rgba(255,255,255,0.03);}
+.stat-number{font-family:'Bebas Neue',sans-serif;font-size:2.5rem;line-height:1;color:var(--gold);margin-bottom:.25rem;}
+.stat-label{font-size:.72rem;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:1px;}
+
+/* ── SECTIONS ── */
+section{padding:80px 5%;}
+.section-inner{max-width:1200px;margin:0 auto;}
+.section-label{font-size:.75rem;font-weight:700;letter-spacing:2px;text-transform:uppercase;color:var(--gold);margin-bottom:.75rem;}
+.section-title{font-family:'Bebas Neue',sans-serif;font-size:clamp(2.5rem,5vw,4.5rem);line-height:1.0;letter-spacing:1px;margin-bottom:.75rem;}
+.section-sub{color:var(--muted);font-size:1rem;line-height:1.7;}
+
+/* ── BENEFITS ── */
+#benefits{background:var(--surface);}
+.benefits-intro{text-align:center;margin-bottom:3rem;}
+.benefits-intro .section-sub{max-width:580px;margin:0 auto;}
+.benefits-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;}
+.benefit-card{background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);padding:2rem;position:relative;overflow:hidden;transition:all .3s;}
+.benefit-card::before{content:'';position:absolute;top:0;left:0;right:0;height:2px;background:linear-gradient(90deg,var(--red),var(--gold));opacity:0;transition:opacity .3s;}
+.benefit-card:hover{transform:translateY(-4px);border-color:rgba(249,115,22,0.25);}
+.benefit-card:hover::before{opacity:1;}
+.benefit-num{font-family:'Bebas Neue',sans-serif;font-size:3rem;line-height:1;color:rgba(192,57,43,0.2);position:absolute;top:.75rem;right:1.25rem;}
+.benefit-icon{font-size:2rem;margin-bottom:1rem;}
+.benefit-card h3{font-size:1.1rem;font-weight:800;margin-bottom:.5rem;}
+.benefit-card p{font-size:.88rem;color:var(--muted);line-height:1.65;}
+
+/* ── HOW IT WORKS ── */
+#how{background:var(--bg);}
+.how-grid{display:grid;grid-template-columns:1fr 1fr;gap:4rem;align-items:center;}
+.how-steps{display:flex;flex-direction:column;gap:1.5rem;}
+.how-step{display:flex;gap:1.25rem;align-items:flex-start;}
+.how-step-num{width:44px;height:44px;border-radius:50%;background:linear-gradient(135deg,var(--red),var(--gold));display:flex;align-items:center;justify-content:center;font-family:'Bebas Neue',sans-serif;font-size:1.2rem;flex-shrink:0;box-shadow:0 4px 16px rgba(192,57,43,0.3);}
+.how-step-text h3{font-size:1rem;font-weight:800;margin-bottom:.3rem;}
+.how-step-text p{font-size:.88rem;color:var(--muted);line-height:1.6;}
+.how-visual{background:var(--surface);border:1px solid var(--border);border-radius:20px;padding:2.5rem;position:relative;overflow:hidden;}
+.how-visual::before{content:'';position:absolute;inset:0;background:radial-gradient(ellipse 60% 60% at 80% 20%,rgba(192,57,43,0.08),transparent);}
+.member-preview{position:relative;z-index:1;}
+.member-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:1.5rem;padding-bottom:1rem;border-bottom:1px solid var(--border);}
+.member-header-logo{display:flex;align-items:center;gap:.5rem;}
+.member-header-logo img{height:28px;width:auto;}
+.member-header-logo span{font-family:'Barlow Condensed',sans-serif;font-weight:900;font-size:.9rem;letter-spacing:.05em;}
+.member-badge{background:rgba(192,57,43,0.15);border:1px solid rgba(192,57,43,0.3);color:var(--red);font-size:.65rem;font-weight:800;padding:.2rem .6rem;border-radius:100px;letter-spacing:1px;text-transform:uppercase;}
+.member-list{display:flex;flex-direction:column;gap:.75rem;}
+.member-row{display:flex;align-items:center;gap:.75rem;padding:.75rem;background:rgba(255,255,255,0.03);border-radius:8px;border:1px solid var(--border);}
+.member-avatar{width:36px;height:36px;border-radius:50%;background:linear-gradient(135deg,var(--red),var(--gold));display:flex;align-items:center;justify-content:center;font-weight:800;font-size:.8rem;flex-shrink:0;}
+.member-info{flex:1;}
+.member-name{font-size:.88rem;font-weight:700;}
+.member-trade{font-size:.72rem;color:var(--muted);}
+.member-revenue{font-family:'Barlow Condensed',sans-serif;font-size:.95rem;font-weight:900;color:var(--gold);}
+
+/* ── EVENTS ── */
+#events{background:var(--surface);}
+.events-header{text-align:center;margin-bottom:3rem;}
+.events-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;}
+.event-card{background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);overflow:hidden;transition:all .3s;}
+.event-card:hover{transform:translateY(-4px);border-color:rgba(192,57,43,0.3);box-shadow:0 20px 50px rgba(0,0,0,0.4);}
+.event-card-top{padding:1.5rem 1.5rem 0;border-bottom:1px solid var(--border);padding-bottom:1.25rem;}
+.event-tag{display:inline-block;background:rgba(192,57,43,0.12);color:var(--red);font-size:.65rem;font-weight:800;padding:.2rem .6rem;border-radius:4px;margin-bottom:1rem;letter-spacing:1px;text-transform:uppercase;}
+.event-tag.gold{background:rgba(249,115,22,0.12);color:var(--gold);}
+.event-card h3{font-family:'Barlow Condensed',sans-serif;font-size:1.4rem;font-weight:900;line-height:1.1;margin-bottom:.5rem;}
+.event-location{font-size:.8rem;color:var(--muted);}
+.event-card-bottom{padding:1.25rem 1.5rem;display:flex;align-items:center;justify-content:space-between;}
+.event-date{font-size:.82rem;font-weight:600;color:var(--muted);}
+.event-price{font-family:'Barlow Condensed',sans-serif;font-size:1.2rem;font-weight:900;color:var(--gold);}
+.event-cta{display:inline-flex;align-items:center;gap:.35rem;background:var(--red);color:#fff;padding:.5rem 1rem;border-radius:6px;font-size:.78rem;font-weight:700;letter-spacing:.5px;text-transform:uppercase;transition:all .2s;border:none;cursor:pointer;text-decoration:none;}
+.event-cta:hover{background:var(--red-light);}
+.event-cta-ghost{border:1px solid rgba(255,255,255,0.15);color:var(--muted);}
+.event-cta-ghost:hover{border-color:var(--gold);color:var(--gold);background:transparent;}
+
+/* ── APPLY SECTION ── */
+#apply-cta{background:linear-gradient(160deg,#0d0505 0%,#1a0808 40%,#0a0a0a 100%);text-align:center;position:relative;overflow:hidden;}
+#apply-cta::before{content:'';position:absolute;top:-200px;left:50%;transform:translateX(-50%);width:800px;height:600px;border-radius:50%;background:radial-gradient(circle,rgba(192,57,43,0.12) 0%,transparent 70%);pointer-events:none;}
+.apply-inner{max-width:640px;margin:0 auto;position:relative;z-index:1;}
+.apply-icon{width:80px;height:80px;border-radius:16px;margin:0 auto 2rem;overflow:hidden;border:1px solid rgba(255,255,255,0.1);background:rgba(255,255,255,0.05);display:flex;align-items:center;justify-content:center;}
+.apply-icon img{width:65%;height:65%;object-fit:contain;}
+.apply-inner h2{font-family:'Bebas Neue',sans-serif;font-size:clamp(2.5rem,5vw,4rem);line-height:1.0;letter-spacing:1px;margin-bottom:.75rem;}
+.apply-inner h2 span{color:var(--red);}
+.apply-inner p{color:var(--muted);font-size:1rem;line-height:1.75;margin-bottom:2rem;max-width:520px;margin-left:auto;margin-right:auto;}
+.apply-note{display:inline-flex;align-items:center;gap:.5rem;background:rgba(249,115,22,0.08);border:1px solid rgba(249,115,22,0.2);border-radius:100px;padding:.4rem 1rem;font-size:.78rem;color:var(--gold);font-weight:600;margin-top:1.5rem;}
+
+/* ── FAQ ── */
+#faq{background:var(--bg);}
+.faq-inner{max-width:760px;margin:0 auto;}
+.faq-list{display:flex;flex-direction:column;gap:.75rem;margin-top:2.5rem;}
+.faq-item{background:var(--surface);border:1px solid var(--border);border-radius:10px;overflow:hidden;}
+.faq-q{width:100%;background:none;border:none;color:var(--text);text-align:left;padding:1.25rem 1.5rem;font-family:'Barlow',sans-serif;font-size:.95rem;font-weight:600;cursor:pointer;display:flex;justify-content:space-between;align-items:center;gap:1rem;}
+.faq-q::after{content:'+';font-size:1.4rem;font-weight:300;color:var(--gold);transition:transform .3s;flex-shrink:0;}
+.faq-item.open .faq-q::after{transform:rotate(45deg);}
+.faq-a{max-height:0;overflow:hidden;transition:max-height .35s ease,padding .35s ease;}
+.faq-a-inner{padding:0 1.5rem 1.25rem;font-size:.9rem;color:var(--muted);line-height:1.7;}
+.faq-item.open .faq-a{max-height:300px;}
+
+/* ── FOOTER ── */
+footer{background:var(--surface);border-top:1px solid var(--border);padding:60px 5% 30px;}
+.footer-inner{max-width:1280px;margin:0 auto;}
+.footer-top{display:grid;grid-template-columns:1.5fr 1fr 1fr;gap:2.5rem;margin-bottom:3rem;}
+.footer-brand-logo{display:flex;align-items:center;gap:.6rem;margin-bottom:.75rem;}
+.footer-brand-logo img{height:36px;width:auto;}
+.footer-brand-logo-text{font-family:'Barlow Condensed',sans-serif;font-weight:900;font-size:1.1rem;letter-spacing:.05em;}
+.footer-brand p{font-size:.85rem;color:var(--muted);line-height:1.6;max-width:240px;}
+.footer-col h4{font-size:.75rem;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:var(--muted);margin-bottom:1rem;}
+.footer-col ul{list-style:none;display:flex;flex-direction:column;gap:.6rem;}
+.footer-col a{font-size:.88rem;color:var(--muted);transition:color .2s;}
+.footer-col a:hover{color:var(--text);}
+.footer-col span{font-size:.88rem;color:var(--muted);}
+.footer-bottom{border-top:1px solid var(--border);padding-top:1.5rem;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem;}
+.footer-bottom p{font-size:.8rem;color:var(--muted);}
+.footer-social{display:flex;gap:.6rem;}
+.fsoc{width:34px;height:34px;border-radius:6px;background:var(--surface2);border:1px solid var(--border);color:var(--muted);display:flex;align-items:center;justify-content:center;text-decoration:none;transition:all .2s;}
+.fsoc:hover{border-color:var(--red);}
+
+/* ── REVEAL ── */
+.reveal{opacity:0;transform:translateY(30px);transition:opacity .6s ease,transform .6s ease;}
+.reveal.visible{opacity:1;transform:none;}
+.reveal-delay-1{transition-delay:.1s;}
+.reveal-delay-2{transition-delay:.2s;}
+
+/* ── RESPONSIVE ── */
+@media(max-width:1024px){
+  .benefits-grid{grid-template-columns:repeat(2,1fr);}
+  .events-grid{grid-template-columns:repeat(2,1fr);}
+  .how-grid{grid-template-columns:1fr;gap:2.5rem;}
+  .footer-top{grid-template-columns:1fr 1fr;}
+}
+@media(max-width:768px){
+  nav{padding:0 4%;}
+  .nav-links{display:none;}
+  .nav-hamburger{display:flex;}
+  section{padding:60px 4%;}
+  .hero{padding:100px 4% 60px;}
+  .hero h1{font-size:clamp(3rem,10vw,5rem);}
+  .hero-stats{flex-wrap:wrap;}
+  .hero-stat{min-width:50%;}
+  .benefits-grid{grid-template-columns:1fr;}
+  .events-grid{grid-template-columns:1fr;}
+  .footer-top{grid-template-columns:1fr 1fr;gap:1.5rem;}
+  .footer-bottom{flex-direction:column;text-align:center;}
+  .hero-ctas{flex-direction:column;align-items:center;}
+  .btn-primary,.btn-ghost{width:100%;max-width:320px;text-align:center;}
+}
+@media(max-width:480px){
+  .footer-top{grid-template-columns:1fr;}
+  .hero-stat{min-width:50%;}
+}
+</style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav>
+  <a href="index.html" class="nav-logo">
+    <img src="https://storage.googleapis.com/msgsndr/kfZT6c91jZcZU6PUztl8/media/69387c0a578cc7a588bf9199.png" alt="Contractor Arsenal">
+    <span class="nav-logo-text">Contractor Arsenal</span>
+  </a>
+  <div class="nav-links">
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="arsenal.html" class="active">Arsenal 001</a>
+    <a href="apply.html" class="nav-cta">Apply Now</a>
+  </div>
+  <button class="nav-hamburger" onclick="toggleMenu()" aria-label="Menu">
+    <span></span><span></span><span></span>
+  </button>
+</nav>
+<div class="nav-mobile" id="navMobile">
+  <a href="index.html" onclick="closeMenu()">Home</a>
+  <a href="about.html" onclick="closeMenu()">About</a>
+  <a href="arsenal.html" onclick="closeMenu()">Arsenal 001</a>
+  <a href="apply.html" onclick="closeMenu()">Apply Now</a>
+</div>
+
+<!-- HERO -->
+<section class="hero">
+  <div class="hero-bg"></div>
+  <div class="noise-overlay"></div>
+  <div class="hero-content">
+    <div class="hero-badge">Private Membership Network</div>
+    <h1>
+      The Inner Circle<br>
+      for <span class="line-gold">Elite</span><br>
+      <span class="line-red">Contractors</span>
+    </h1>
+    <p class="hero-sub">A private network where the most ambitious contractors in America connect, build, and win together. Apply to join Arsenal 001.</p>
+    <div class="hero-ctas">
+      <a href="apply.html" class="btn-primary">Apply for Membership</a>
+      <a href="#benefits" class="btn-ghost">See Member Benefits</a>
+    </div>
+    <div class="hero-stats">
+      <div class="hero-stat">
+        <div class="stat-number">3.2%</div>
+        <div class="stat-label">Acceptance Rate</div>
+      </div>
+      <div class="hero-stat">
+        <div class="stat-number">124</div>
+        <div class="stat-label">Members</div>
+      </div>
+      <div class="hero-stat">
+        <div class="stat-number">31</div>
+        <div class="stat-label">States</div>
+      </div>
+      <div class="hero-stat">
+        <div class="stat-number">$24M+</div>
+        <div class="stat-label">Combined Revenue</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- BENEFITS -->
+<section id="benefits">
+  <div class="section-inner">
+    <div class="benefits-intro reveal">
+      <div class="section-label">Member Benefits</div>
+      <h2 class="section-title">Engage with the Best<br>in the Business</h2>
+      <p class="section-sub">As a member of Arsenal 001, you get access to a network of operators who are serious about growing. No tire kickers. No noise. Just results-driven contractors.</p>
+    </div>
+    <div class="benefits-grid">
+      <div class="benefit-card reveal">
+        <div class="benefit-num">01</div>
+        <div class="benefit-icon">🤝</div>
+        <h3>Private Referral Network</h3>
+        <p>Connect with non-competing contractors across the country. Send and receive high-quality referrals from members you know and trust.</p>
+      </div>
+      <div class="benefit-card reveal reveal-delay-1">
+        <div class="benefit-num">02</div>
+        <div class="benefit-icon">📞</div>
+        <h3>Monthly Mastermind Calls</h3>
+        <p>Live group calls with top-performing members. Share what's working, get feedback on your business, and hear from industry leaders.</p>
+      </div>
+      <div class="benefit-card reveal reveal-delay-2">
+        <div class="benefit-num">03</div>
+        <div class="benefit-icon">🌎</div>
+        <h3>Exclusive Events &amp; Retreats</h3>
+        <p>Annual retreats, city meetups, and field experiences with the Arsenal family. Build relationships that last beyond business.</p>
+      </div>
+      <div class="benefit-card reveal">
+        <div class="benefit-num">04</div>
+        <div class="benefit-icon">🎯</div>
+        <h3>Business Growth Resources</h3>
+        <p>Templates, scripts, hiring guides, and playbooks from contractors doing $1M to $10M+. Skip the mistakes they already made.</p>
+      </div>
+      <div class="benefit-card reveal reveal-delay-1">
+        <div class="benefit-num">05</div>
+        <div class="benefit-icon">💰</div>
+        <h3>Group Vendor Deals</h3>
+        <p>Group buying power on materials, equipment, software, and services. Members save thousands per year through collective negotiation.</p>
+      </div>
+      <div class="benefit-card reveal reveal-delay-2">
+        <div class="benefit-num">06</div>
+        <div class="benefit-icon">🏆</div>
+        <h3>Elite Accountability</h3>
+        <p>Set your goals with people who push you. Quarterly accountability check-ins with members at your level or higher.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- HOW IT WORKS -->
+<section id="how">
+  <div class="section-inner">
+    <div class="how-grid">
+      <div>
+        <div class="section-label reveal">How Membership Works</div>
+        <h2 class="section-title reveal">Built for Contractors<br>Who are Serious</h2>
+        <p class="section-sub reveal" style="margin-bottom:2.5rem">Arsenal 001 is invitation-based with an application process. We keep the group small, curated, and high-quality. Here's how to get in.</p>
+        <div class="how-steps">
+          <div class="how-step reveal">
+            <div class="how-step-num">01</div>
+            <div class="how-step-text">
+              <h3>Submit Your Application</h3>
+              <p>Tell us about your business, your revenue, your goals, and why you want in. Applications are reviewed personally.</p>
+            </div>
+          </div>
+          <div class="how-step reveal">
+            <div class="how-step-num">02</div>
+            <div class="how-step-text">
+              <h3>Interview Call</h3>
+              <p>If you pass the initial review, we'll get on a quick call to assess fit and make sure Arsenal 001 is right for you.</p>
+            </div>
+          </div>
+          <div class="how-step reveal">
+            <div class="how-step-num">03</div>
+            <div class="how-step-text">
+              <h3>Get Your Invite</h3>
+              <p>Accepted members receive their invitation, onboarding materials, and access to the private community and first call.</p>
+            </div>
+          </div>
+          <div class="how-step reveal">
+            <div class="how-step-num">04</div>
+            <div class="how-step-text">
+              <h3>Start Building with the Best</h3>
+              <p>Connect with your cohort, join the mastermind calls, and start leveraging the network to grow your business.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="how-visual reveal reveal-delay-1">
+        <div class="member-preview">
+          <div class="member-header">
+            <div class="member-header-logo">
+              <img src="https://storage.googleapis.com/msgsndr/kfZT6c91jZcZU6PUztl8/media/69387c0a578cc7a588bf9199.png" alt="">
+              <span>Arsenal 001</span>
+            </div>
+            <div class="member-badge">Members</div>
+          </div>
+          <div class="member-list">
+            <div class="member-row">
+              <div class="member-avatar">JR</div>
+              <div class="member-info">
+                <div class="member-name">Jake R.</div>
+                <div class="member-trade">Roofing — Houston, TX</div>
+              </div>
+              <div class="member-revenue">$2.4M</div>
+            </div>
+            <div class="member-row">
+              <div class="member-avatar">MP</div>
+              <div class="member-info">
+                <div class="member-name">Marcus P.</div>
+                <div class="member-trade">HVAC — Atlanta, GA</div>
+              </div>
+              <div class="member-revenue">$1.8M</div>
+            </div>
+            <div class="member-row">
+              <div class="member-avatar">TW</div>
+              <div class="member-info">
+                <div class="member-name">Tyler W.</div>
+                <div class="member-trade">Remodeling — Denver, CO</div>
+              </div>
+              <div class="member-revenue">$3.1M</div>
+            </div>
+            <div class="member-row">
+              <div class="member-avatar">AL</div>
+              <div class="member-info">
+                <div class="member-name">Amanda L.</div>
+                <div class="member-trade">Landscaping — Phoenix, AZ</div>
+              </div>
+              <div class="member-revenue">$920K</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- EVENTS -->
+<section id="events">
+  <div class="section-inner">
+    <div class="events-header reveal">
+      <div class="section-label">Events</div>
+      <h2 class="section-title">Get in the Room<br>with the Best</h2>
+      <p class="section-sub" style="max-width:560px;margin:.5rem auto 0">Arsenal 001 hosts exclusive events for members throughout the year. From annual retreats to monthly calls, we build in-person and online.</p>
+    </div>
+    <div class="events-grid">
+      <div class="event-card reveal">
+        <div class="event-card-top">
+          <div class="event-tag">Annual</div>
+          <h3>Winter Mastermind</h3>
+          <p class="event-location">Scottsdale, AZ</p>
+        </div>
+        <div style="padding:1.25rem 1.5rem;border-bottom:1px solid var(--border);">
+          <p style="font-size:.85rem;color:var(--muted);line-height:1.65">3-day intensive for Arsenal 001 members. Strategy sessions, peer reviews, goal setting for the year ahead. Limited to 30 members.</p>
+        </div>
+        <div class="event-card-bottom">
+          <div>
+            <div class="event-date">January 15-17, 2026</div>
+            <div class="event-price">$1,200</div>
+          </div>
+          <a href="apply.html" class="event-cta">Apply to Attend</a>
+        </div>
+      </div>
+      <div class="event-card reveal reveal-delay-1">
+        <div class="event-card-top">
+          <div class="event-tag gold">Retreat</div>
+          <h3>Summer Growth Retreat</h3>
+          <p class="event-location">Nashville, TN</p>
+        </div>
+        <div style="padding:1.25rem 1.5rem;border-bottom:1px solid var(--border);">
+          <p style="font-size:.85rem;color:var(--muted);line-height:1.65">4-day members retreat. Guest speakers, workshops, and networking with the full Arsenal 001 cohort. The best event of the year.</p>
+        </div>
+        <div class="event-card-bottom">
+          <div>
+            <div class="event-date">July 10-13, 2026</div>
+            <div class="event-price">$1,800</div>
+          </div>
+          <a href="apply.html" class="event-cta">Apply to Attend</a>
+        </div>
+      </div>
+      <div class="event-card reveal reveal-delay-2">
+        <div class="event-card-top">
+          <div class="event-tag">Monthly</div>
+          <h3>Mastermind Calls</h3>
+          <p class="event-location">Virtual — Zoom</p>
+        </div>
+        <div style="padding:1.25rem 1.5rem;border-bottom:1px solid var(--border);">
+          <p style="font-size:.85rem;color:var(--muted);line-height:1.65">Monthly group calls with all active members. Hot seat sessions, peer coaching, and accountability. Free for all Arsenal 001 members.</p>
+        </div>
+        <div class="event-card-bottom">
+          <div>
+            <div class="event-date">Every Last Thursday</div>
+            <div class="event-price">Included</div>
+          </div>
+          <a href="apply.html" class="event-cta event-cta-ghost">Apply for Access</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- APPLY CTA -->
+<section id="apply-cta">
+  <div class="noise-overlay"></div>
+  <div class="section-inner">
+    <div class="apply-inner reveal">
+      <div class="apply-icon">
+        <img src="https://storage.googleapis.com/msgsndr/kfZT6c91jZcZU6PUztl8/media/69387c0a578cc7a588bf9199.png" alt="Contractor Arsenal">
+      </div>
+      <h2>Ready to Join the <span>Inner Circle?</span></h2>
+      <p>Arsenal 001 accepts a new cohort twice per year. Applications are reviewed personally. Submit yours before the next window closes.</p>
+      <div class="hero-ctas">
+        <a href="apply.html" class="btn-primary">Apply for Arsenal 001</a>
+      </div>
+      <div class="apply-note">
+        3.2% acceptance rate — Quality over quantity
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section id="faq">
+  <div class="section-inner">
+    <div class="faq-inner">
+      <div style="text-align:center;" class="reveal">
+        <div class="section-label" style="display:inline-block">FAQ</div>
+        <h2 class="section-title" style="margin-top:.5rem">The Only Network<br>Worth Getting Into</h2>
+      </div>
+      <div class="faq-list">
+        <div class="faq-item">
+          <button class="faq-q" onclick="toggleFaq(this)">What is Arsenal 001?</button>
+          <div class="faq-a"><div class="faq-a-inner">Arsenal 001 is a private, invitation-based membership network for serious contractors. It's a place to connect with other high-performing operators, share knowledge, get referrals, and grow your business faster than you could alone. We keep the group small and curated — quality over quantity, always.</div></div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-q" onclick="toggleFaq(this)">How do I join?</button>
+          <div class="faq-a"><div class="faq-a-inner">Submit an application through our apply page. We review every application personally. If you pass the initial screen, we'll invite you to a short interview call. Accepted members receive an invitation when a spot becomes available in the next cohort.</div></div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-q" onclick="toggleFaq(this)">How do I get invited to Arsenal 001?</button>
+          <div class="faq-a"><div class="faq-a-inner">You can apply directly through this page or be referred by a current member. Current members can refer other contractors they know personally and would vouch for. Referred applicants are fast-tracked through the review process.</div></div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-q" onclick="toggleFaq(this)">Who is in Arsenal 001?</button>
+          <div class="faq-a"><div class="faq-a-inner">Arsenal 001 members are contractors across the US doing meaningful revenue — typically $500K to $5M+ annually. Painters, roofers, HVAC, plumbers, landscapers, remodelers, and more. The common thread: they're serious, growth-oriented, and genuinely want to help other members win.</div></div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-q" onclick="toggleFaq(this)">What does membership cost?</button>
+          <div class="faq-a"><div class="faq-a-inner">Membership details including cost are shared during the interview process. Events and retreats are separately priced. Monthly mastermind calls are included for all active members.</div></div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-q" onclick="toggleFaq(this)">What does the cost cover?</button>
+          <div class="faq-a"><div class="faq-a-inner">Membership includes access to the private community, monthly mastermind calls, the member directory and referral network, group vendor deals, and growth resources. Event travel and accommodations are separate costs.</div></div>
+        </div>
+        <div class="faq-item">
+          <button class="faq-q" onclick="toggleFaq(this)">What happens if I'm rejected?</button>
+          <div class="faq-a"><div class="faq-a-inner">Being rejected from Arsenal 001 doesn't mean we think less of your business — it may simply mean the current cohort isn't the right fit or is full. We'll let you know clearly, and you're welcome to reapply when the next cohort opens. We'd rather tell you upfront than waste your time.</div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div class="footer-inner">
+    <div class="footer-top">
+      <div class="footer-brand">
+        <div class="footer-brand-logo">
+          <img src="https://storage.googleapis.com/msgsndr/kfZT6c91jZcZU6PUztl8/media/69387c0a578cc7a588bf9199.png" alt="Contractor Arsenal">
+          <span class="footer-brand-logo-text">Contractor Arsenal</span>
+        </div>
+        <p>Done-for-you websites built for contractors who want more local jobs and less tech headaches.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Navigate</h4>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="apply.html">Apply Now</a></li>
+          <li><a href="arsenal.html">Arsenal 001</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Services</h4>
+        <ul>
+          <li><span>Website Design</span></li>
+          <li><span>Local SEO</span></li>
+          <li><span>Copywriting</span></li>
+          <li><span>Mobile Optimization</span></li>
+          <li><span>Ongoing Support</span></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-bottom">
+      <p>&copy; 2025 Contractor Arsenal. All rights reserved.</p>
+      <div class="footer-social">
+        <a href="https://www.instagram.com/contractorarsenal/" target="_blank" rel="noopener" class="fsoc" title="Instagram">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none"><defs><linearGradient id="ig" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#FFDC80"/><stop offset="30%" stop-color="#F77737"/><stop offset="60%" stop-color="#C13584"/><stop offset="100%" stop-color="#515BD4"/></linearGradient></defs><rect x="2" y="2" width="20" height="20" rx="5.5" fill="url(#ig)"/><circle cx="12" cy="12" r="4.2" stroke="#fff" stroke-width="1.8" fill="none"/><circle cx="17.2" cy="6.8" r="1.1" fill="#fff"/></svg>
+        </a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<script>
+function toggleMenu(){document.getElementById('navMobile').classList.toggle('open');}
+function closeMenu(){document.getElementById('navMobile').classList.remove('open');}
+function toggleFaq(btn){
+  var item=btn.closest('.faq-item');
+  var isOpen=item.classList.contains('open');
+  document.querySelectorAll('.faq-item.open').forEach(function(i){i.classList.remove('open');});
+  if(!isOpen) item.classList.add('open');
+}
+var obs=new IntersectionObserver(function(entries){
+  entries.forEach(function(e){if(e.isIntersecting){e.target.classList.add('visible');obs.unobserve(e.target);}});
+},{threshold:0.1,rootMargin:'0px 0px -40px 0px'});
+document.querySelectorAll('.reveal').forEach(function(r){obs.observe(r);});
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,23 +4,16 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Contractor Arsenal - Websites That Win You More Jobs</title>
-<meta name="description" content="Done-for-you websites built specifically for contractors. Rank locally, convert visitors into calls. Painters, roofers, landscapers, remodelers.">
+<meta name="description" content="Done-for-you websites built for contractors. Any trade, any market. Rank on Google, get more calls, launch in 48-72 hours.">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700;800;900&family=Barlow+Condensed:wght@600;700;800;900&family=Bebas+Neue&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css">
 <style>
-:root {
-  --bg: #0a0a0a;
-  --surface: #111111;
-  --surface2: #1a1a1a;
-  --border: rgba(255,255,255,0.08);
-  --red: #C0392B;
-  --red-light: #E74C3C;
-  --gold: #F97316;
-  --gold-light: #FB923C;
-  --text: #f0f0f0;
-  --muted: #888;
-  --radius: 12px;
+:root{
+  --bg:#0a0a0a;--surface:#111111;--surface2:#1a1a1a;
+  --border:rgba(255,255,255,0.08);
+  --red:#C0392B;--red-light:#E74C3C;
+  --gold:#F97316;--gold-light:#FB923C;
+  --text:#f0f0f0;--muted:#888;--radius:12px;
 }
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
 html{scroll-behavior:smooth;}
@@ -28,64 +21,76 @@ body{background:var(--bg);color:var(--text);font-family:'Barlow',sans-serif;over
 a{color:inherit;text-decoration:none;}
 img{max-width:100%;height:auto;display:block;}
 
-/* NAV */
-nav{position:fixed;top:0;left:0;right:0;z-index:1000;padding:0 5%;display:flex;align-items:center;justify-content:space-between;height:68px;background:rgba(10,10,10,0.92);backdrop-filter:blur(12px);border-bottom:1px solid var(--border);}
-.nav-logo{font-family:'Bebas Neue',sans-serif;font-size:1.5rem;letter-spacing:2px;color:var(--text);}
-.nav-logo span{color:var(--red);}
-.nav-links{display:flex;gap:2rem;align-items:center;}
-.nav-links a{font-weight:600;font-size:.85rem;letter-spacing:.5px;text-transform:uppercase;opacity:.8;transition:opacity .2s;}
+/* ── NAV ── */
+nav{position:fixed;top:0;left:0;right:0;z-index:1000;padding:0 5%;display:flex;align-items:center;justify-content:space-between;height:68px;background:rgba(10,10,10,0.95);backdrop-filter:blur(14px);border-bottom:1px solid var(--border);}
+.nav-logo{display:flex;align-items:center;gap:.6rem;}
+.nav-logo img{height:38px;width:auto;}
+.nav-logo-text{font-family:'Barlow Condensed',sans-serif;font-weight:900;font-size:1.1rem;letter-spacing:.05em;color:var(--text);}
+.nav-links{display:flex;gap:1.5rem;align-items:center;}
+.nav-links a{font-weight:600;font-size:.82rem;letter-spacing:.5px;text-transform:uppercase;color:var(--text);opacity:.75;transition:opacity .2s;}
 .nav-links a:hover{opacity:1;}
-.nav-cta{background:var(--red);color:#fff;padding:.55rem 1.3rem;border-radius:6px;font-weight:700;font-size:.85rem;letter-spacing:.5px;text-transform:uppercase;transition:background .2s;}
-.nav-cta:hover{background:var(--red-light);opacity:1;}
-.nav-hamburger{display:none;flex-direction:column;gap:5px;cursor:pointer;padding:4px;}
+.nav-links a.active{opacity:1;color:var(--gold);}
+.nav-cta{background:var(--red);color:#fff !important;padding:.5rem 1.25rem;border-radius:6px;font-weight:700;opacity:1 !important;transition:background .2s;}
+.nav-cta:hover{background:var(--red-light);}
+.nav-hamburger{display:none;flex-direction:column;gap:5px;cursor:pointer;padding:4px;background:none;border:none;}
 .nav-hamburger span{display:block;width:24px;height:2px;background:var(--text);border-radius:2px;transition:.3s;}
-.nav-mobile{display:none;position:fixed;top:68px;left:0;right:0;background:rgba(10,10,10,.98);padding:1.5rem 5%;flex-direction:column;gap:1.2rem;z-index:999;border-bottom:1px solid var(--border);}
+.nav-mobile{display:none;position:fixed;top:68px;left:0;right:0;background:rgba(10,10,10,.98);padding:1.5rem 5%;flex-direction:column;gap:0;z-index:999;border-bottom:1px solid var(--border);}
 .nav-mobile.open{display:flex;}
-.nav-mobile a{font-weight:600;font-size:1rem;text-transform:uppercase;letter-spacing:.5px;padding:.5rem 0;border-bottom:1px solid var(--border);}
+.nav-mobile a{font-weight:600;font-size:1rem;text-transform:uppercase;letter-spacing:.5px;padding:.9rem 0;border-bottom:1px solid var(--border);color:var(--text);}
+.nav-mobile a:hover{color:var(--gold);}
 
-/* HERO */
-.hero{min-height:100vh;display:flex;align-items:center;padding:100px 5% 60px;position:relative;overflow:hidden;background:var(--bg);}
-.hero::before{content:'';position:absolute;inset:0;background:radial-gradient(ellipse 70% 60% at 20% 50%, rgba(192,57,43,0.15) 0%, transparent 70%);pointer-events:none;}
-.hero-inner{display:grid;grid-template-columns:1fr 1fr;gap:3rem;align-items:center;max-width:1280px;margin:0 auto;width:100%;}
-.hero-left{z-index:2;}
+/* ── HERO: FULL-BLEED BACKGROUND SLIDESHOW ── */
+.hero{min-height:100vh;display:flex;align-items:center;padding:100px 5% 60px;position:relative;overflow:hidden;}
+
+/* Background slides sit behind everything */
+.hero-bg{position:absolute;inset:0;z-index:0;}
+.hero-slide{position:absolute;inset:0;opacity:0;transition:opacity 1.4s ease-in-out;}
+.hero-slide.active{opacity:1;}
+.hero-slide img{width:100%;height:100%;object-fit:cover;object-position:center right;}
+
+/* Gradient: solid dark on left → transparent on right so images show through */
+.hero-overlay{
+  position:absolute;inset:0;z-index:1;
+  background:linear-gradient(108deg,
+    #0a0a0a 28%,
+    rgba(10,10,10,0.90) 46%,
+    rgba(10,10,10,0.45) 68%,
+    rgba(10,10,10,0.15) 100%
+  );
+}
+/* Brand red glow */
+.hero::before{content:'';position:absolute;inset:0;z-index:2;pointer-events:none;background:radial-gradient(ellipse 55% 80% at 0% 50%,rgba(192,57,43,0.18) 0%,transparent 70%);}
+/* Noise */
+.noise-overlay{position:absolute;inset:0;z-index:2;opacity:.04;pointer-events:none;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");background-size:200px;}
+
+/* Content above all overlays */
+.hero-content{position:relative;z-index:3;max-width:1280px;margin:0 auto;width:100%;}
+.hero-inner{max-width:640px;}
+
 .hero-eyebrow{display:inline-flex;align-items:center;gap:.5rem;background:rgba(249,115,22,0.12);border:1px solid rgba(249,115,22,0.3);color:var(--gold);padding:.35rem .85rem;border-radius:100px;font-size:.78rem;font-weight:700;letter-spacing:1px;text-transform:uppercase;margin-bottom:1.5rem;}
 .hero-eyebrow::before{content:'';width:6px;height:6px;border-radius:50%;background:var(--gold);animation:blink 1.5s infinite;}
 @keyframes blink{0%,100%{opacity:1;}50%{opacity:.3;}}
-.hero h1{font-family:'Bebas Neue',sans-serif;font-size:clamp(3.2rem,6vw,5.5rem);line-height:1.0;letter-spacing:1px;margin-bottom:1rem;}
+.hero h1{font-family:'Bebas Neue',sans-serif;font-size:clamp(3.5rem,7vw,6.5rem);line-height:1.0;letter-spacing:1px;margin-bottom:1rem;text-shadow:0 2px 20px rgba(0,0,0,0.5);}
 .hero h1 .accent-red{color:var(--red);}
 .hero h1 .accent-gold{color:var(--gold);}
-.hero-sub{font-size:1.1rem;color:var(--muted);max-width:480px;margin-bottom:2rem;line-height:1.7;}
-.hero-actions{display:flex;gap:1rem;flex-wrap:wrap;}
-.btn-primary{background:var(--red);color:#fff;padding:.85rem 2rem;border-radius:8px;font-weight:700;font-size:1rem;letter-spacing:.5px;text-transform:uppercase;transition:all .2s;border:2px solid var(--red);}
+.hero-sub{font-size:1.1rem;color:rgba(240,240,240,0.85);max-width:480px;margin-bottom:2rem;line-height:1.7;}
+.hero-actions{display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:1.8rem;}
+.btn-primary{background:var(--red);color:#fff;padding:.85rem 2rem;border-radius:8px;font-weight:700;font-size:1rem;letter-spacing:.5px;text-transform:uppercase;transition:all .2s;border:2px solid var(--red);display:inline-block;}
 .btn-primary:hover{background:var(--red-light);border-color:var(--red-light);transform:translateY(-2px);}
-.btn-outline{border:2px solid var(--gold);color:var(--gold);padding:.85rem 2rem;border-radius:8px;font-weight:700;font-size:1rem;letter-spacing:.5px;text-transform:uppercase;transition:all .2s;}
+.btn-outline{border:2px solid var(--gold);color:var(--gold);padding:.85rem 2rem;border-radius:8px;font-weight:700;font-size:1rem;letter-spacing:.5px;text-transform:uppercase;transition:all .2s;display:inline-block;}
 .btn-outline:hover{background:var(--gold);color:#000;transform:translateY(-2px);}
-.hero-trust{margin-top:1.8rem;display:flex;gap:1.5rem;align-items:center;flex-wrap:wrap;}
-.trust-item{display:flex;align-items:center;gap:.4rem;font-size:.82rem;color:var(--muted);}
-.trust-item svg{width:14px;height:14px;fill:var(--gold);}
+.hero-trust{display:flex;gap:1.5rem;align-items:center;flex-wrap:wrap;}
+.trust-item{display:flex;align-items:center;gap:.4rem;font-size:.82rem;color:rgba(240,240,240,0.65);}
+.trust-item svg{width:14px;height:14px;fill:var(--gold);flex-shrink:0;}
 
-/* SWIPER HERO */
-.hero-right{position:relative;z-index:2;}
-.swiper-hero-wrap{position:relative;animation:floatY 4s ease-in-out infinite;}
-@keyframes floatY{0%,100%{transform:translateY(0);}50%{transform:translateY(-18px);}  }
-.swiper-hero{width:100%;max-width:540px;margin:0 auto;overflow:visible !important;}
-.swiper-hero .swiper-wrapper{padding:30px 0;}
-.swiper-hero .swiper-slide{border-radius:14px;overflow:hidden;box-shadow:0 20px 60px rgba(0,0,0,0.6);transition:transform .4s;}
-.swiper-hero .swiper-slide img{width:100%;height:320px;object-fit:cover;display:block;}
-.swiper-hero .swiper-slide-active{box-shadow:0 30px 80px rgba(192,57,43,0.4);}
-.swiper-gradient-overlay{position:absolute;bottom:0;left:0;right:0;height:120px;background:linear-gradient(to top,var(--bg),transparent);pointer-events:none;z-index:5;border-radius:0 0 14px 14px;}
-
-/* NOISE TEXTURE */
-.noise-overlay{position:absolute;inset:0;opacity:.04;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");background-size:200px 200px;pointer-events:none;}
-
-/* SECTION COMMON */
+/* ── SECTIONS ── */
 section{padding:80px 5%;}
 .section-inner{max-width:1280px;margin:0 auto;}
 .section-label{font-size:.75rem;font-weight:700;letter-spacing:2px;text-transform:uppercase;color:var(--gold);margin-bottom:.75rem;}
 .section-title{font-family:'Barlow Condensed',sans-serif;font-size:clamp(2rem,4vw,3rem);font-weight:800;line-height:1.15;margin-bottom:1rem;}
 .section-sub{color:var(--muted);max-width:580px;font-size:1rem;}
 
-/* PROBLEM */
+/* ── PROBLEM ── */
 .problem{background:var(--surface);}
 .problem-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;margin-top:3rem;}
 .problem-card{background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);padding:1.75rem;position:relative;overflow:hidden;}
@@ -94,7 +99,7 @@ section{padding:80px 5%;}
 .problem-card h3{font-size:1.05rem;font-weight:700;margin-bottom:.5rem;}
 .problem-card p{font-size:.9rem;color:var(--muted);line-height:1.6;}
 
-/* SOLUTION */
+/* ── SOLUTION ── */
 .solution-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;margin-top:3rem;}
 .solution-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.75rem;transition:transform .3s,border-color .3s;}
 .solution-card:hover{transform:translateY(-4px);border-color:rgba(249,115,22,0.3);}
@@ -102,14 +107,14 @@ section{padding:80px 5%;}
 .solution-card h3{font-size:1.05rem;font-weight:700;margin-bottom:.5rem;}
 .solution-card p{font-size:.9rem;color:var(--muted);line-height:1.6;}
 
-/* LEAD DEMO */
+/* ── LEAD DEMO ── */
 .lead-demo{background:var(--surface);border-radius:24px;padding:3rem;max-width:960px;margin:3rem auto 0;position:relative;overflow:hidden;border:1px solid var(--border);}
 .lead-demo::before{content:'';position:absolute;inset:0;background:radial-gradient(ellipse 60% 50% at 80% 50%,rgba(249,115,22,0.07),transparent);pointer-events:none;}
 .lead-demo-inner{display:grid;grid-template-columns:1fr 1fr;gap:3rem;align-items:center;}
 .lead-demo-copy .section-title{font-size:clamp(1.6rem,3vw,2.2rem);}
 .lead-demo-copy ul{list-style:none;margin-top:1.5rem;display:flex;flex-direction:column;gap:.8rem;}
 .lead-demo-copy li{display:flex;align-items:flex-start;gap:.75rem;font-size:.95rem;color:var(--muted);}
-.lead-demo-copy li::before{content:'';width:18px;height:18px;min-width:18px;border-radius:50%;background:var(--gold);margin-top:2px;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 10l4 4 6-7' stroke='%23000' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");background-size:14px 14px;background-repeat:no-repeat;background-position:center;}
+.lead-demo-copy li::before{content:'';width:18px;height:18px;min-width:18px;border-radius:50%;background:var(--gold);margin-top:2px;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5 10l4 4 6-7' stroke='%23000' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");background-size:14px;background-repeat:no-repeat;background-position:center;}
 .lead-notif{background:var(--bg);border-radius:14px;border:1px solid var(--border);padding:1.5rem;display:flex;flex-direction:column;gap:1rem;}
 .notif-item{display:flex;align-items:center;gap:.85rem;background:var(--surface2);border-radius:10px;padding:1rem;animation:slideIn .5s ease both;}
 @keyframes slideIn{from{opacity:0;transform:translateX(20px);}to{opacity:1;transform:none;}}
@@ -120,25 +125,28 @@ section{padding:80px 5%;}
 .notif-text span{font-size:.78rem;color:var(--muted);}
 .notif-dot{width:8px;height:8px;border-radius:50%;background:var(--gold);margin-left:auto;flex-shrink:0;animation:blink 2s infinite;}
 
-/* HOW IT WORKS */
+/* ── HOW IT WORKS ── */
 .how{background:linear-gradient(135deg,rgba(192,57,43,0.05),rgba(249,115,22,0.03));}
 .steps{display:grid;grid-template-columns:repeat(3,1fr);gap:2rem;margin-top:3rem;position:relative;}
 .steps::before{content:'';position:absolute;top:52px;left:calc(16.66% + 1rem);right:calc(16.66% + 1rem);height:2px;background:linear-gradient(90deg,var(--red),var(--gold));z-index:0;}
 .step{text-align:center;position:relative;z-index:1;}
-.step-num{width:64px;height:64px;border-radius:50%;background:linear-gradient(135deg,var(--red),var(--gold));display:flex;align-items:center;justify-content:center;font-family:'Bebas Neue',sans-serif;font-size:1.6rem;letter-spacing:1px;margin:0 auto 1.25rem;box-shadow:0 8px 30px rgba(192,57,43,0.35);}
+.step-num{width:64px;height:64px;border-radius:50%;background:linear-gradient(135deg,var(--red),var(--gold));display:flex;align-items:center;justify-content:center;font-family:'Bebas Neue',sans-serif;font-size:1.6rem;margin:0 auto 1.25rem;box-shadow:0 8px 30px rgba(192,57,43,0.35);}
 .step h3{font-size:1.1rem;font-weight:700;margin-bottom:.5rem;}
 .step p{font-size:.9rem;color:var(--muted);line-height:1.6;}
 
-/* CONTRACTOR TYPES */
+/* ── CONTRACTOR TYPES ── */
 .types{background:var(--surface);}
-.types-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1.25rem;margin-top:3rem;}
-.type-card{background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);padding:1.75rem 1.25rem;text-align:center;transition:all .3s;cursor:default;}
+.types-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:1.25rem;margin-top:2.5rem;}
+.type-card{background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);padding:1.75rem 1.25rem;text-align:center;transition:all .3s;}
 .type-card:hover{border-color:rgba(192,57,43,0.4);transform:translateY(-4px);}
 .type-icon{font-size:2.5rem;margin-bottom:1rem;display:block;}
 .type-card h3{font-size:1.05rem;font-weight:700;margin-bottom:.4rem;}
 .type-card p{font-size:.82rem;color:var(--muted);}
+.types-note{margin-top:2rem;padding:1.25rem 1.75rem;background:rgba(249,115,22,0.06);border:1px solid rgba(249,115,22,0.2);border-radius:var(--radius);text-align:center;}
+.types-note p{font-size:.92rem;color:var(--muted);}
+.types-note a{color:var(--gold);font-weight:700;}
 
-/* COMPARE */
+/* ── COMPARE ── */
 .compare{background:var(--bg);}
 .compare-table-wrap{overflow-x:auto;margin-top:3rem;border-radius:var(--radius);border:1px solid var(--border);}
 .compare-table{width:100%;border-collapse:collapse;min-width:640px;}
@@ -150,14 +158,14 @@ section{padding:80px 5%;}
 .check{color:var(--gold);font-weight:700;}
 .cross{color:var(--muted);opacity:.5;}
 
-/* METRICS */
+/* ── METRICS ── */
 .metrics{background:linear-gradient(135deg,rgba(192,57,43,0.08),rgba(249,115,22,0.05));border-top:1px solid var(--border);border-bottom:1px solid var(--border);}
 .metrics-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:2rem;margin-top:2rem;text-align:center;}
 .metric-num{font-family:'Bebas Neue',sans-serif;font-size:clamp(3rem,6vw,5rem);line-height:1;color:var(--gold);margin-bottom:.25rem;}
 .metric-label{font-size:.85rem;color:var(--muted);text-transform:uppercase;letter-spacing:1px;}
 .metric-sub{font-size:.78rem;color:var(--muted);opacity:.6;margin-top:.2rem;}
 
-/* TESTIMONIALS */
+/* ── TESTIMONIALS ── */
 .testi{background:var(--surface);}
 .testi-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem;margin-top:3rem;}
 .testi-card{background:var(--bg);border:1px solid var(--border);border-radius:var(--radius);padding:1.75rem;transition:transform .3s;}
@@ -169,7 +177,7 @@ section{padding:80px 5%;}
 .testi-name strong{display:block;font-size:.9rem;font-weight:700;}
 .testi-name span{font-size:.78rem;color:var(--muted);}
 
-/* FAQ */
+/* ── FAQ ── */
 .faq{background:var(--bg);}
 .faq-list{max-width:760px;margin:2.5rem auto 0;display:flex;flex-direction:column;gap:.75rem;}
 .faq-item{background:var(--surface);border:1px solid var(--border);border-radius:10px;overflow:hidden;}
@@ -180,46 +188,45 @@ section{padding:80px 5%;}
 .faq-a-inner{padding:0 1.5rem 1.25rem;font-size:.9rem;color:var(--muted);line-height:1.7;}
 .faq-item.open .faq-a{max-height:300px;}
 
-/* FINAL CTA */
+/* ── FINAL CTA ── */
 .final-cta{background:linear-gradient(135deg,rgba(192,57,43,0.15),rgba(249,115,22,0.08));border-top:1px solid var(--border);text-align:center;padding:100px 5%;}
 .final-cta h2{font-family:'Bebas Neue',sans-serif;font-size:clamp(2.5rem,5vw,4.5rem);letter-spacing:1px;margin-bottom:1rem;}
 .final-cta h2 .accent-gold{color:var(--gold);}
 .final-cta p{color:var(--muted);font-size:1.05rem;max-width:500px;margin:0 auto 2.5rem;}
 .cta-actions{display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;}
 
-/* FOOTER */
+/* ── FOOTER ── */
 footer{background:var(--surface);border-top:1px solid var(--border);padding:60px 5% 30px;}
 .footer-inner{max-width:1280px;margin:0 auto;}
-.footer-top{display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:2.5rem;margin-bottom:3rem;}
-.footer-brand .logo{font-family:'Bebas Neue',sans-serif;font-size:1.4rem;letter-spacing:2px;margin-bottom:.75rem;}
-.footer-brand .logo span{color:var(--red);}
-.footer-brand p{font-size:.85rem;color:var(--muted);line-height:1.6;max-width:220px;}
+.footer-top{display:grid;grid-template-columns:1.5fr 1fr 1fr;gap:2.5rem;margin-bottom:3rem;}
+.footer-brand-logo{display:flex;align-items:center;gap:.6rem;margin-bottom:.75rem;}
+.footer-brand-logo img{height:36px;width:auto;}
+.footer-brand-logo-text{font-family:'Barlow Condensed',sans-serif;font-weight:900;font-size:1.1rem;letter-spacing:.05em;}
+.footer-brand p{font-size:.85rem;color:var(--muted);line-height:1.6;max-width:240px;}
 .footer-col h4{font-size:.75rem;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:var(--muted);margin-bottom:1rem;}
 .footer-col ul{list-style:none;display:flex;flex-direction:column;gap:.6rem;}
-.footer-col li{font-size:.88rem;color:var(--muted);}
-.footer-col a{color:var(--muted);transition:color .2s;}
+.footer-col a{font-size:.88rem;color:var(--muted);transition:color .2s;}
 .footer-col a:hover{color:var(--text);}
+.footer-col span{font-size:.88rem;color:var(--muted);}
 .footer-bottom{border-top:1px solid var(--border);padding-top:1.5rem;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem;}
 .footer-bottom p{font-size:.8rem;color:var(--muted);}
-.footer-legal{display:flex;gap:1.5rem;}
-.footer-legal span{font-size:.8rem;color:var(--muted);}
+.footer-social{display:flex;gap:.6rem;}
+.fsoc{width:34px;height:34px;border-radius:6px;background:var(--surface2);border:1px solid var(--border);color:var(--muted);display:flex;align-items:center;justify-content:center;text-decoration:none;transition:all .2s;}
+.fsoc:hover{border-color:var(--red);}
 
-/* SCROLL REVEAL */
+/* ── SCROLL REVEAL ── */
 .reveal{opacity:0;transform:translateY(30px);transition:opacity .6s ease,transform .6s ease;}
 .reveal.visible{opacity:1;transform:none;}
 .reveal-delay-1{transition-delay:.1s;}
 .reveal-delay-2{transition-delay:.2s;}
 .reveal-delay-3{transition-delay:.3s;}
 
-/* MOBILE */
+/* ── RESPONSIVE ── */
 @media(max-width:1024px){
-  .hero-inner{grid-template-columns:1fr;}
-  .hero-right{order:-1;max-width:500px;margin:0 auto;}
-  .swiper-hero{max-width:400px;}
-  .swiper-hero .swiper-slide img{height:260px;}
   .solution-grid{grid-template-columns:repeat(2,1fr);}
   .types-grid{grid-template-columns:repeat(2,1fr);}
   .footer-top{grid-template-columns:1fr 1fr;}
+  .lead-demo-inner{grid-template-columns:1fr;}
 }
 @media(max-width:768px){
   nav{padding:0 4%;}
@@ -227,17 +234,15 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:60px
   .nav-hamburger{display:flex;}
   section{padding:60px 4%;}
   .hero{padding:90px 4% 60px;}
-  .hero-inner{gap:2rem;}
-  .hero h1{font-size:clamp(2.5rem,10vw,3.5rem);}
+  .hero h1{font-size:clamp(2.8rem,10vw,4rem);}
+  .hero-overlay{background:linear-gradient(108deg,#0a0a0a 45%,rgba(10,10,10,0.85) 70%,rgba(10,10,10,0.6) 100%);}
   .problem-grid,.steps,.testi-grid{grid-template-columns:1fr;}
   .steps::before{display:none;}
   .solution-grid{grid-template-columns:1fr;}
   .types-grid{grid-template-columns:repeat(2,1fr);}
   .metrics-grid{grid-template-columns:1fr;gap:1.5rem;}
-  .lead-demo-inner{grid-template-columns:1fr;}
   .footer-top{grid-template-columns:1fr 1fr;gap:1.5rem;}
   .footer-bottom{flex-direction:column;text-align:center;}
-  .swiper-hero .swiper-slide img{height:220px;}
   .hero-actions{flex-direction:column;}
   .btn-primary,.btn-outline{text-align:center;}
   .cta-actions{flex-direction:column;align-items:center;}
@@ -245,8 +250,7 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:60px
 @media(max-width:480px){
   .types-grid{grid-template-columns:1fr;}
   .footer-top{grid-template-columns:1fr;}
-  .hero h1{font-size:2.4rem;}
-  .swiper-hero .swiper-slide img{height:180px;}
+  .hero h1{font-size:2.8rem;}
 }
 </style>
 </head>
@@ -254,34 +258,69 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:60px
 
 <!-- NAV -->
 <nav>
-  <a href="index.html" class="nav-logo">Contractor<span>Arsenal</span></a>
+  <a href="index.html" class="nav-logo">
+    <img src="https://storage.googleapis.com/msgsndr/kfZT6c91jZcZU6PUztl8/media/69387c0a578cc7a588bf9199.png" alt="Contractor Arsenal">
+    <span class="nav-logo-text">Contractor Arsenal</span>
+  </a>
   <div class="nav-links">
-    <a href="index.html">Home</a>
+    <a href="index.html" class="active">Home</a>
     <a href="about.html">About</a>
+    <a href="arsenal.html">Arsenal 001</a>
     <a href="apply.html" class="nav-cta">Apply Now</a>
   </div>
-  <div class="nav-hamburger" onclick="toggleMenu()" aria-label="Menu">
+  <button class="nav-hamburger" onclick="toggleMenu()" aria-label="Menu">
     <span></span><span></span><span></span>
-  </div>
+  </button>
 </nav>
 <div class="nav-mobile" id="navMobile">
-  <a href="index.html">Home</a>
-  <a href="about.html">About</a>
-  <a href="apply.html">Apply Now</a>
+  <a href="index.html" onclick="closeMenu()">Home</a>
+  <a href="about.html" onclick="closeMenu()">About</a>
+  <a href="arsenal.html" onclick="closeMenu()">Arsenal 001</a>
+  <a href="apply.html" onclick="closeMenu()">Apply Now</a>
 </div>
 
 <!-- HERO -->
-<section class="hero" id="hero">
+<section class="hero">
+  <!-- Background slideshow — fades between portfolio images -->
+  <div class="hero-bg">
+    <div class="hero-slide active">
+      <img src="https://github.com/user-attachments/assets/e1706902-da3a-419b-8cd1-862fbd61082b" alt="" aria-hidden="true" loading="eager">
+    </div>
+    <div class="hero-slide">
+      <img src="https://github.com/user-attachments/assets/32b1e767-b22d-41cd-bea9-7bf145b638aa" alt="" aria-hidden="true" loading="lazy">
+    </div>
+    <div class="hero-slide">
+      <img src="https://github.com/user-attachments/assets/b3e6b468-65c7-4b60-b2b7-3b9f0d08ba47" alt="" aria-hidden="true" loading="lazy">
+    </div>
+    <div class="hero-slide">
+      <img src="https://github.com/user-attachments/assets/fb0e9956-c523-456c-b499-2b979a111bc5" alt="" aria-hidden="true" loading="lazy">
+    </div>
+    <div class="hero-slide">
+      <img src="https://github.com/user-attachments/assets/92e12d9a-5c1a-4231-8b58-2a874f063539" alt="" aria-hidden="true" loading="lazy">
+    </div>
+    <div class="hero-slide">
+      <img src="https://github.com/user-attachments/assets/dd186500-6297-4699-9002-ef0fb2a3f1d3" alt="" aria-hidden="true" loading="lazy">
+    </div>
+    <div class="hero-slide">
+      <img src="https://github.com/user-attachments/assets/957e7a58-7b91-4b73-944e-e67e7afc3657" alt="" aria-hidden="true" loading="lazy">
+    </div>
+    <div class="hero-slide">
+      <img src="https://github.com/user-attachments/assets/f242403d-f7b6-45b0-aa37-2f96fec89b19" alt="" aria-hidden="true" loading="lazy">
+    </div>
+  </div>
+  <!-- Gradient + noise overlays -->
+  <div class="hero-overlay"></div>
   <div class="noise-overlay"></div>
-  <div class="hero-inner">
-    <div class="hero-left">
+  <!-- Content -->
+  <div class="hero-content">
+    <div class="hero-inner">
       <div class="hero-eyebrow">Done-For-You Contractor Websites</div>
       <h1>
         Websites That<br>
         <span class="accent-red">Win Jobs.</span><br>
         <span class="accent-gold">Not Just Looks.</span>
       </h1>
-      <p class="hero-sub">We build high-converting websites specifically for contractors. Rank on Google. Get more calls. Launch in 48 to 72 hours.</p>
+      <p class="hero-sub">We build high-converting websites for contractors. Rank on Google. Get more calls. Launch in 48 to 72 hours.</p>
       <div class="hero-actions">
         <a href="apply.html" class="btn-primary">Apply For Your Site</a>
         <a href="about.html" class="btn-outline">See How It Works</a>
@@ -290,22 +329,6 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:60px
         <div class="trust-item"><svg viewBox="0 0 20 20"><path d="M10 1l2.39 4.84 5.34.78-3.87 3.77.91 5.32L10 13.27l-4.77 2.44.91-5.32L2.27 6.62l5.34-.78z"/></svg> Contractor specialists</div>
         <div class="trust-item"><svg viewBox="0 0 20 20"><path d="M10 1l2.39 4.84 5.34.78-3.87 3.77.91 5.32L10 13.27l-4.77 2.44.91-5.32L2.27 6.62l5.34-.78z"/></svg> 48-72hr launch</div>
         <div class="trust-item"><svg viewBox="0 0 20 20"><path d="M10 1l2.39 4.84 5.34.78-3.87 3.77.91 5.32L10 13.27l-4.77 2.44.91-5.32L2.27 6.62l5.34-.78z"/></svg> No tech skills needed</div>
-      </div>
-    </div>
-    <div class="hero-right">
-      <div class="swiper-hero-wrap">
-        <div class="swiper swiper-hero">
-          <div class="swiper-wrapper">
-            <div class="swiper-slide"><img src="https://github.com/user-attachments/assets/e1706902-da3a-419b-8cd1-862fbd61082b" alt="Contractor website example 1" loading="eager"></div>
-            <div class="swiper-slide"><img src="https://github.com/user-attachments/assets/32b1e767-b22d-41cd-bea9-7bf145b638aa" alt="Contractor website example 2" loading="lazy"></div>
-            <div class="swiper-slide"><img src="https://github.com/user-attachments/assets/b3e6b468-65c7-4b60-b2b7-3b9f0d08ba47" alt="Contractor website example 3" loading="lazy"></div>
-            <div class="swiper-slide"><img src="https://github.com/user-attachments/assets/fb0e9956-c523-456c-b499-2b979a111bc5" alt="Contractor website example 4" loading="lazy"></div>
-            <div class="swiper-slide"><img src="https://github.com/user-attachments/assets/92e12d9a-5c1a-4231-8b58-2a874f063539" alt="Contractor website example 5" loading="lazy"></div>
-            <div class="swiper-slide"><img src="https://github.com/user-attachments/assets/dd186500-6297-4699-9002-ef0fb2a3f1d3" alt="Contractor website example 6" loading="lazy"></div>
-            <div class="swiper-slide"><img src="https://github.com/user-attachments/assets/957e7a58-7b91-4b73-944e-e67e7afc3657" alt="Contractor website example 7" loading="lazy"></div>
-            <div class="swiper-slide"><img src="https://github.com/user-attachments/assets/f242403d-f7b6-45b0-aa37-2f96fec89b19" alt="Contractor website example 8" loading="lazy"></div>
-          </div>
-        </div>
       </div>
     </div>
   </div>
@@ -449,17 +472,17 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:60px
   </div>
 </section>
 
-<!-- CONTRACTOR TYPES -->
+<!-- WHO WE SERVE -->
 <section class="types">
   <div class="section-inner">
     <div class="section-label">Who We Serve</div>
-    <h2 class="section-title">Built for Your Trade</h2>
-    <p class="section-sub">We specialize in home service contractors. We know your customers, your market, and what it takes to win.</p>
+    <h2 class="section-title">Built for Every Contractor</h2>
+    <p class="section-sub">If you do residential or commercial work, we build for you. We know the trades, the keywords, and exactly what converts in your market.</p>
     <div class="types-grid">
       <div class="type-card reveal">
         <span class="type-icon">🎨</span>
         <h3>Painters</h3>
-        <p>Interior, exterior, cabinet painting. We rank you for high-value residential jobs in your city.</p>
+        <p>Interior, exterior, cabinet painting. Rank for high-value residential jobs in your city.</p>
       </div>
       <div class="type-card reveal reveal-delay-1">
         <span class="type-icon">🏠</span>
@@ -474,8 +497,31 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:60px
       <div class="type-card reveal reveal-delay-3">
         <span class="type-icon">🔨</span>
         <h3>Remodelers</h3>
-        <p>Kitchen, bath, whole-home. Position yourself as the premium choice for high-ticket remodel projects.</p>
+        <p>Kitchen, bath, whole-home. Position yourself as the premium choice for high-ticket projects.</p>
       </div>
+      <div class="type-card reveal">
+        <span class="type-icon">❄️</span>
+        <h3>HVAC</h3>
+        <p>Heating, cooling, installation, and service. Own the seasonal search spikes in your area.</p>
+      </div>
+      <div class="type-card reveal reveal-delay-1">
+        <span class="type-icon">🔧</span>
+        <h3>Plumbers</h3>
+        <p>Emergency service, installations, and remodels. Rank when homeowners need help fast.</p>
+      </div>
+      <div class="type-card reveal reveal-delay-2">
+        <span class="type-icon">⚡</span>
+        <h3>Electricians</h3>
+        <p>Residential and commercial electrical. Get found for panel upgrades, EV chargers, and more.</p>
+      </div>
+      <div class="type-card reveal reveal-delay-3">
+        <span class="type-icon">🏗️</span>
+        <h3>General Contractors</h3>
+        <p>New builds, additions, renovations. A site that reflects the scale and quality of your work.</p>
+      </div>
+    </div>
+    <div class="types-note">
+      <p>Don't see your trade? <a href="apply.html">Apply anyway</a> — if you do residential or commercial work, we can build for you.</p>
     </div>
   </div>
 </section>
@@ -638,7 +684,7 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:60px
       </div>
       <div class="faq-item">
         <button class="faq-q" onclick="toggleFaq(this)">What trades do you work with?</button>
-        <div class="faq-a"><div class="faq-a-inner">We specialize in painting, roofing, landscaping, and remodeling. We may also be a fit for other home service contractors. Apply and we'll let you know if we're a good match.</div></div>
+        <div class="faq-a"><div class="faq-a-inner">We build for any contractor doing residential or commercial work. Painters, roofers, landscapers, remodelers, HVAC, plumbers, electricians, general contractors and more. Apply and we'll confirm we're a good fit.</div></div>
       </div>
       <div class="faq-item">
         <button class="faq-q" onclick="toggleFaq(this)">Do I own the website?</button>
@@ -664,8 +710,20 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:60px
   <div class="footer-inner">
     <div class="footer-top">
       <div class="footer-brand">
-        <div class="logo">Contractor<span>Arsenal</span></div>
+        <div class="footer-brand-logo">
+          <img src="https://storage.googleapis.com/msgsndr/kfZT6c91jZcZU6PUztl8/media/69387c0a578cc7a588bf9199.png" alt="Contractor Arsenal">
+          <span class="footer-brand-logo-text">Contractor Arsenal</span>
+        </div>
         <p>Done-for-you websites built for contractors who want more local jobs and less tech headaches.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Navigate</h4>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="apply.html">Apply Now</a></li>
+          <li><a href="arsenal.html">Arsenal 001</a></li>
+        </ul>
       </div>
       <div class="footer-col">
         <h4>Services</h4>
@@ -677,81 +735,47 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:60px
           <li><span>Ongoing Support</span></li>
         </ul>
       </div>
-      <div class="footer-col">
-        <h4>Company</h4>
-        <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="about.html">About</a></li>
-          <li><span>Results</span></li>
-          <li><span>FAQ</span></li>
-          <li><a href="apply.html">Apply Now</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Get Started</h4>
-        <ul>
-          <li><a href="apply.html">Apply for Your Site</a></li>
-          <li><span>Instagram DM Us</span></li>
-          <li><span>Free Consultation</span></li>
-        </ul>
-      </div>
     </div>
     <div class="footer-bottom">
-      <p>2025 Contractor Arsenal. All rights reserved.</p>
-      <div class="footer-legal">
-        <span>Privacy Policy</span>
-        <span>Terms of Service</span>
+      <p>&copy; 2025 Contractor Arsenal. All rights reserved.</p>
+      <div class="footer-social">
+        <a href="https://www.instagram.com/contractorarsenal/" target="_blank" rel="noopener" class="fsoc" title="Instagram">
+          <svg viewBox="0 0 24 24" width="18" height="18" fill="none"><defs><linearGradient id="ig" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#FFDC80"/><stop offset="30%" stop-color="#F77737"/><stop offset="60%" stop-color="#C13584"/><stop offset="100%" stop-color="#515BD4"/></linearGradient></defs><rect x="2" y="2" width="20" height="20" rx="5.5" fill="url(#ig)"/><circle cx="12" cy="12" r="4.2" stroke="#fff" stroke-width="1.8" fill="none"/><circle cx="17.2" cy="6.8" r="1.1" fill="#fff"/></svg>
+        </a>
       </div>
     </div>
   </div>
 </footer>
 
-<script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
 <script>
 // NAV
-function toggleMenu() {
-  document.getElementById('navMobile').classList.toggle('open');
-}
+function toggleMenu(){document.getElementById('navMobile').classList.toggle('open');}
+function closeMenu(){document.getElementById('navMobile').classList.remove('open');}
 
-// SWIPER
-new Swiper('.swiper-hero', {
-  effect: 'coverflow',
-  grabCursor: true,
-  centeredSlides: true,
-  slidesPerView: 'auto',
-  loop: true,
-  coverflowEffect: {
-    rotate: 30,
-    stretch: 0,
-    depth: 120,
-    modifier: 1,
-    slideShadows: true
-  },
-  autoplay: {
-    delay: 2800,
-    disableOnInteraction: false
-  },
-  breakpoints: {
-    0: { slidesPerView: 1.2 },
-    480: { slidesPerView: 1.4 },
-    768: { slidesPerView: 1.6 },
-    1024: { slidesPerView: 1.8 }
-  }
-});
+// HERO BACKGROUND SLIDESHOW
+(function(){
+  var slides = document.querySelectorAll('.hero-slide');
+  var current = 0;
+  if(!slides.length) return;
+  setInterval(function(){
+    slides[current].classList.remove('active');
+    current = (current + 1) % slides.length;
+    slides[current].classList.add('active');
+  }, 3600);
+})();
 
 // SCROLL REVEAL
-const reveals = document.querySelectorAll('.reveal');
-const obs = new IntersectionObserver((entries) => {
-  entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('visible'); obs.unobserve(e.target); } });
-}, { threshold: 0.1, rootMargin: '0px 0px -50px 0px' });
-reveals.forEach(r => obs.observe(r));
+var obs = new IntersectionObserver(function(entries){
+  entries.forEach(function(e){if(e.isIntersecting){e.target.classList.add('visible');obs.unobserve(e.target);}});
+},{threshold:0.1,rootMargin:'0px 0px -50px 0px'});
+document.querySelectorAll('.reveal').forEach(function(r){obs.observe(r);});
 
 // FAQ
-function toggleFaq(btn) {
-  var item = btn.closest('.faq-item');
-  var isOpen = item.classList.contains('open');
-  document.querySelectorAll('.faq-item.open').forEach(i => i.classList.remove('open'));
-  if (!isOpen) item.classList.add('open');
+function toggleFaq(btn){
+  var item=btn.closest('.faq-item');
+  var isOpen=item.classList.contains('open');
+  document.querySelectorAll('.faq-item.open').forEach(function(i){i.classList.remove('open');});
+  if(!isOpen) item.classList.add('open');
 }
 </script>
 </body>


### PR DESCRIPTION
- Redesigned hero: images now transition smoothly behind the headline text using full-bleed CSS fade slideshow with dark-to-transparent gradient overlay so all heading/body text stays fully readable at all times
- Removed Swiper dependency from index.html (replaced with native JS)
- Expanded "Who We Serve" to 8 trade types (added HVAC, Plumbing, Electricians, General Contractors) with "apply anyway" note for unlisted trades
- Unified nav across all pages: logo icon + Contractor Arsenal text + Arsenal 001 link
- Unified footer across all pages: only Home, About, Apply, Arsenal 001 are clickable
- Matched dark theme (--bg:#0a0a0a) consistently across index, about, and apply
- Created arsenal.html: Arsenal 001 private members club page with hero stats, benefits grid (01-06), how-it-works section, events cards, apply CTA, and full FAQ

https://claude.ai/code/session_01JKGm9sPhpa8pPUZCEf6Xri